### PR TITLE
Use environment variables for secrets and DB config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DB_USER=postgres
+DB_PASSWORD=yourpassword
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=coworkspace
+JWT_SECRET=your_jwt_secret
+#PORT=3000

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -2,7 +2,7 @@ const pool = require('../db');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 
-const JWT_SECRET = 'co-workspace-secret'; // puoi spostarlo in .env
+const JWT_SECRET = process.env.JWT_SECRET;
 
 // ✅ Registrazione
 exports.register = async (req, res) => {

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,11 +1,12 @@
+require('dotenv').config();
 const { Pool } = require('pg');
 
 const pool = new Pool({
-  user: 'postgres',           // <-- usa l'utente con cui hai fatto il login
-  host: 'localhost',
-  database: 'coworkspace',
-  password: 'teiubesc1', // <-- inserisci la password che hai usato prima
-  port: 5432,
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  port: Number(process.env.DB_PORT) || 5432,
 });
 
 module.exports = pool;

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const JWT_SECRET = 'co-workspace-secret';
+const JWT_SECRET = process.env.JWT_SECRET;
 
 exports.verificaToken = (req, res, next) => {
   const authHeader = req.headers['authorization'];

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
+        "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3"
@@ -183,6 +184,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3"

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const app = express();


### PR DESCRIPTION
## Summary
- add dotenv dependency
- load env variables for db config and JWT secret
- document variables in .env.example

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688e0a6101a88328bafe506730421f76