### PR TITLE
Use 'admin' role string consistently across app

### DIFF
--- a/backend/middleware/adminMiddleware.js
+++ b/backend/middleware/adminMiddleware.js
@@ -1,8 +1,8 @@
 
 exports.verificaAdmin = (req, res, next) => {
-  if (req.utente && req.utente.ruolo === 'amministratore') {
+  if (req.utente && req.utente.ruolo === 'admin') {
     next();
   } else {
-    res.status(403).json({ message: 'Accesso riservato agli amministratori' });
+    res.status(403).json({ message: 'Accesso riservato agli admin' });
   }
 };

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -19,8 +19,8 @@ exports.verificaToken = (req, res, next) => {
 
 // Middleware per autorizzazione ruolo admin
 exports.verificaAdmin = (req, res, next) => {
-  if (req.utente?.ruolo !== 'amministratore') {
-    return res.status(403).json({ message: 'Accesso negato: solo amministratori' });
+  if (req.utente?.ruolo !== 'admin') {
+    return res.status(403).json({ message: 'Accesso negato: solo admin' });
   }
   next();
 };

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -2,8 +2,8 @@ $(document).ready(function () {
   const token = localStorage.getItem('token');
   const utente = JSON.parse(localStorage.getItem('utente'));
 
-  if (!token || !utente || utente.ruolo !== 'amministratore') {
-    alert("Accesso negato. Solo amministratori possono entrare.");
+  if (!token || !utente || utente.ruolo !== 'admin') {
+    alert("Accesso negato. Solo admin possono entrare.");
     window.location.href = "index.html";
     return;
   }


### PR DESCRIPTION
## Summary
- Replace legacy `'amministratore'` role string with `'admin'` in backend middleware and admin frontend check
- Ensure database schema and user creation use `'admin'` role value

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e101ea5188328baf65f9466d2e8d3