### PR TITLE
Serve frontend via Express

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,14 +1,17 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '../frontend')));
 
 // Rotte
+app.get('/', (_, res) => res.sendFile(path.join(__dirname, '../frontend/index.html')));
 app.use('/api', require('./routes/authRoutes'));           // Login, registrazione, logout
 app.use('/api', require('./routes/userRoutes'));           // Profilo utente
 app.use('/api/sedi', require('./routes/sediRoutes'));


### PR DESCRIPTION
## Summary
- serve static frontend assets from `backend/server.js`
- add root route to deliver `index.html`

## Testing
- `npm test` (fails: no test specified)
- `curl http://localhost:3000` returns index page

------
https://chatgpt.com/codex/tasks/task_e_688e1a8e641c8328915af6e948003a22