### PR TITLE
Add filters and detail endpoint for sedi

### DIFF
--- a/backend/routes/sediRoutes.js
+++ b/backend/routes/sediRoutes.js
@@ -9,6 +9,9 @@ router.post('/', verificaToken, sediController.aggiungiSede);
 // Recupera sedi per gestore (protetto)
 router.get('/gestore/:id', verificaToken, sediController.getSediGestore);
 
+// Dettaglio di una singola sede
+router.get('/:id', sediController.getSedeById);
+
 // Recupera sedi filtrabili (per client/guest)
 router.get('/', sediController.getSedi);
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -30,8 +30,13 @@ Le rotte che richiedono autenticazione devono includere un token/sessione nel cl
 
 | Metodo | Endpoint           | Descrizione                                                     |
 |--------|--------------------|-----------------------------------------------------------------|
-| GET    | `/api/sedi`        | Visualizza tutte le sedi disponibili (con filtri opzionali)     |
+| GET    | `/api/sedi`        | Visualizza tutte le sedi disponibili (filtri: `citta`, `tipo`, `servizio`) |
 | GET    | `/api/sedi/:id`    | Visualizza i dettagli di una singola sede                       |
+
+Filtri disponibili su `/api/sedi`:
+- `citta`: filtra per città della sede
+- `tipo`: tipologia di spazio (es. scrivania, ufficio, sala)
+- `servizio`: testo da ricercare tra i servizi dello spazio
 
 ---
 


### PR DESCRIPTION
## Summary
- support city, type and service filters when listing sedi
- expose endpoint to fetch a single sede with its spazi
- document available sede filters in API spec

## Testing
- `npm test`
- `node --check backend/controllers/sediController.js`
- `node --check backend/routes/sediRoutes.js`


------
https://chatgpt.com/codex/tasks/task_e_688f1e1cb5b48328b0431f2f36cbd05a