### PR TITLE
Fix role detection for client menu options

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -9,14 +9,16 @@ $(document).ready(function () {
     menu.append('<li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>');
     menu.append('<li class="nav-item"><a class="nav-link" href="sedi.html">Sedi</a></li>');
 
-    if (utente.ruolo === 'cliente') {
+    const ruolo = (utente.ruolo || '').toLowerCase();
+
+    if (ruolo === 'cliente') {
       menu.append('<li class="nav-item"><a class="nav-link" href="prenotazione.html">Prenotazioni</a></li>');
       menu.append('<li class="nav-item"><a class="nav-link" href="pagamento.html">Pagamenti</a></li>');
     }
-    if (utente.ruolo === 'gestore') {
+    if (ruolo === 'gestore') {
       menu.append('<li class="nav-item"><a class="nav-link" href="gestore.html">Gestore</a></li>');
     }
-    if (utente.ruolo === 'admin') {
+    if (ruolo === 'admin') {
       menu.append('<li class="nav-item"><a class="nav-link" href="admin.html">Admin</a></li>');
     }
 


### PR DESCRIPTION
## Summary
- Normalize user role in frontend menu script
- Show booking and payment links when role is `cliente`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2b116c64832891c16be2585e3434