### PR TITLE
Standardize navbar across pages to show user info

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,12 +5,19 @@
   <title>Admin Panel - CoWorkSpace</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="css/style.css" rel="stylesheet" />
 </head>
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
-    <div class="container">
+    <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+
+      <div class="d-flex align-items-center text-white ms-3">
+        <span id="nomeUtente" class="fw-bold"></span>
+        <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+      </div>
+
+      <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">

--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -10,14 +10,20 @@
 <body class="bg-light">
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
-    <div class="container">
+    <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" 
+
+      <div class="d-flex align-items-center text-white ms-3">
+        <span id="nomeUtente" class="fw-bold"></span>
+        <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+      </div>
+
+      <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-<ul id="menuLinks" class="navbar-nav gap-3"></ul>
+        <ul id="menuLinks" class="navbar-nav gap-3"></ul>
       </div>
     </div>
   </nav>

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -8,9 +8,6 @@ $(document).ready(function () {
     return;
   }
 
-  $('#nomeUtente').text(utente.nome);
-  $('#ruoloUtente').text(`(${utente.ruolo})`);
-
   $('#logoutBtn').click(function () {
     localStorage.removeItem('token');
     localStorage.removeItem('utente');

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -5,6 +5,8 @@ $(document).ready(function () {
 
   if (!utente) {
     menu.append('<li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>');
+    $('#nomeUtente').text('');
+    $('#ruoloUtente').text('');
   } else {
     menu.append('<li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>');
     menu.append('<li class="nav-item"><a class="nav-link" href="sedi.html">Sedi</a></li>');
@@ -22,6 +24,9 @@ $(document).ready(function () {
       menu.append('<li class="nav-item"><a class="nav-link" href="admin.html">Admin</a></li>');
     }
 
+    $('#nomeUtente').text(utente.nome || '');
+    $('#ruoloUtente').text(utente.ruolo ? `(${utente.ruolo})` : '');
+
     menu.append('<li class="nav-item"><a class="nav-link" href="#" id="logoutLink">Logout</a></li>');
 
     $('#logoutLink').click(function (e) {
@@ -30,5 +35,10 @@ $(document).ready(function () {
       localStorage.removeItem('utente');
       window.location.href = 'index.html';
     });
+  }
+
+  const navbar = $('.navbar');
+  if (!navbar.is('#mainNavbar')) {
+    navbar.addClass('show');
   }
 });

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -5,12 +5,19 @@
   <title>Pagamento - CoWorkSpace</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="css/style.css" rel="stylesheet" />
 </head>
   <body class="bg-light">
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
-      <div class="container">
+      <div class="container d-flex align-items-center">
         <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+
+        <div class="d-flex align-items-center text-white ms-3">
+          <span id="nomeUtente" class="fw-bold"></span>
+          <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+        </div>
+
+        <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -9,14 +9,20 @@
 </head>
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
-    <div class="container">
+    <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" 
+
+      <div class="d-flex align-items-center text-white ms-3">
+        <span id="nomeUtente" class="fw-bold"></span>
+        <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+      </div>
+
+      <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-<ul id="menuLinks" class="navbar-nav gap-3"></ul>
+        <ul id="menuLinks" class="navbar-nav gap-3"></ul>
       </div>
     </div>
   </nav>

--- a/frontend/sedi.html
+++ b/frontend/sedi.html
@@ -9,13 +9,19 @@
 </head>
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
-    <div class="container">
+    <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+
+      <div class="d-flex align-items-center text-white ms-3">
+        <span id="nomeUtente" class="fw-bold"></span>
+        <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+      </div>
+
+      <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-<ul id="menuLinks" class="navbar-nav gap-3"></ul>
+        <ul id="menuLinks" class="navbar-nav gap-3"></ul>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- Show logged in user's name and role in navbar across dashboard, payment, booking, admin, manager, and locations pages
- Extend shared menu script to populate user info and reveal navbar after login
- Simplify dashboard script by relying on shared menu

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f2c6b7208832881507de61bcc4758