### PR TITLE
Refine dashboard access and editing

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -39,6 +39,7 @@
   <main class="container my-5">
     <section>
       <h2 class="mb-4">Le tue prenotazioni</h2>
+      <div id="dashboardAlert"></div>
       <ul id="listaPrenotazioni" class="list-group shadow-sm"></ul>
     </section>
 

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -41,8 +41,15 @@ $(function () {
         localStorage.setItem('token', response.token);
         localStorage.setItem('utente', JSON.stringify(response.utente));
 
-        // Redirect alla dashboard
-        window.location.href = "dashboard.html";
+        // Redirect in base al ruolo
+        const ruolo = (response.utente.ruolo || '').toLowerCase();
+        if (ruolo === 'gestore') {
+          window.location.href = 'gestore.html';
+        } else if (ruolo === 'admin') {
+          window.location.href = 'admin.html';
+        } else {
+          window.location.href = 'dashboard.html';
+        }
       },
       error: function (xhr) {
         const msg = xhr.responseJSON?.message || 'Errore nel login.';

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -2,9 +2,9 @@ $(document).ready(function () {
   const token = localStorage.getItem('token');
   const utente = JSON.parse(localStorage.getItem('utente') || 'null');
 
-  if (!token || !utente) {
-    alert("Effettua il login per accedere alla dashboard.");
-    window.location.href = "index.html";
+  if (!token || !utente || utente.ruolo !== 'cliente') {
+    alert('Accesso non autorizzato.');
+    window.location.href = 'index.html';
     return;
   }
 
@@ -14,7 +14,9 @@ $(document).ready(function () {
     window.location.href = 'index.html';
   });
 
-  if (utente.ruolo === 'cliente') {
+  function caricaPrenotazioni() {
+    $('#listaPrenotazioni').empty();
+
     $.ajax({
       url: 'http://localhost:3000/api/prenotazioni',
       method: 'GET',
@@ -23,30 +25,62 @@ $(document).ready(function () {
         const prenotazioni = data.prenotazioni || [];
         if (prenotazioni.length === 0) {
           $('#listaPrenotazioni').append('<li class="list-group-item">Nessuna prenotazione trovata.</li>');
-        } else {
-          prenotazioni.forEach(p => {
-            const dataFormattata = new Date(p.data).toLocaleDateString('it-IT', { year: 'numeric', month: '2-digit', day: '2-digit' });
-            const oraInizio = p.orario_inizio ? p.orario_inizio.slice(0, 5) : '';
-            const oraFine = p.orario_fine ? p.orario_fine.slice(0, 5) : '';
-            $('#listaPrenotazioni').append(`
-              <li class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-start">
-                <div>
-                  📍 <strong>Spazio:</strong> ${p.nome_spazio} <br>
-                  🗓️ <strong>Data:</strong> ${dataFormattata}
-                </div>
-                <div class="mt-2 mt-md-0">
-                  ⏰ <strong>Orario:</strong> ${oraInizio} - ${oraFine}
-                </div>
-              </li>
-            `);
-          });
+          return;
         }
+
+        prenotazioni.forEach(p => {
+          const dataFormattata = new Date(p.data).toLocaleDateString('it-IT', { year: 'numeric', month: '2-digit', day: '2-digit' });
+          const oraInizio = p.orario_inizio ? p.orario_inizio.slice(0, 5) : '';
+          const oraFine = p.orario_fine ? p.orario_fine.slice(0, 5) : '';
+          $('#listaPrenotazioni').append(`
+            <li class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-start">
+              <div>
+                📍 <strong>Spazio:</strong> ${p.nome_spazio} <br>
+                🗓️ <strong>Data:</strong> ${dataFormattata}
+              </div>
+              <div class="mt-2 mt-md-0 d-flex flex-column flex-md-row align-items-md-center">
+                ⏰ <strong>Orario:</strong> ${oraInizio} - ${oraFine}
+                <button class="btn btn-sm btn-warning ms-md-3 mt-2 mt-md-0 btnModifica" data-id="${p.id}" data-data="${p.data}" data-inizio="${p.orario_inizio}" data-fine="${p.orario_fine}">Modifica</button>
+              </div>
+            </li>
+          `);
+        });
+
+        $('.btnModifica').click(function () {
+          const id = $(this).data('id');
+          const dataAttuale = $(this).data('data');
+          const inizioAttuale = $(this).data('inizio');
+          const fineAttuale = $(this).data('fine');
+
+          const nuovaData = prompt('Nuova data (YYYY-MM-DD)', dataAttuale);
+          if (!nuovaData) return;
+          const nuovoInizio = prompt('Nuovo orario di inizio (HH:MM)', inizioAttuale);
+          if (!nuovoInizio) return;
+          const nuovoFine = prompt('Nuovo orario di fine (HH:MM)', fineAttuale);
+          if (!nuovoFine) return;
+
+          $.ajax({
+            url: `http://localhost:3000/api/prenotazioni/${id}`,
+            method: 'PUT',
+            contentType: 'application/json',
+            headers: { Authorization: `Bearer ${token}` },
+            data: JSON.stringify({ data: nuovaData, orario_inizio: nuovoInizio, orario_fine: nuovoFine }),
+            success: function () {
+              $('#dashboardAlert').html('<div class="alert alert-success">Prenotazione aggiornata</div>');
+              caricaPrenotazioni();
+            },
+            error: function (xhr) {
+              $('#dashboardAlert').html(`<div class="alert alert-danger">${xhr.responseJSON?.message || 'Errore durante l\\'aggiornamento'}</div>`);
+            }
+          });
+        });
       },
       error: function () {
         $('#listaPrenotazioni').append('<li class="list-group-item text-danger">Errore nel caricamento.</li>');
       }
     });
-  } else {
-    $('#listaPrenotazioni').append('<li class="list-group-item">Nessuna prenotazione da mostrare.</li>');
   }
+
+  caricaPrenotazioni();
 });
+

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -8,12 +8,14 @@ $(document).ready(function () {
     $('#nomeUtente').text('');
     $('#ruoloUtente').text('');
   } else {
-    menu.append('<li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>');
-    menu.append('<li class="nav-item"><a class="nav-link" href="sedi.html">Sedi</a></li>');
-
     const ruolo = (utente.ruolo || '').toLowerCase();
 
+    // Link comuni a tutti gli utenti autenticati
+    menu.append('<li class="nav-item"><a class="nav-link" href="sedi.html">Sedi</a></li>');
+
+    // Link specifici per ruolo
     if (ruolo === 'cliente') {
+      menu.append('<li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>');
       menu.append('<li class="nav-item"><a class="nav-link" href="prenotazione.html">Prenotazioni</a></li>');
       menu.append('<li class="nav-item"><a class="nav-link" href="pagamento.html">Pagamenti</a></li>');
     }

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -138,7 +138,6 @@ $(document).ready(function () {
                   <p class="mb-1"><strong>Data:</strong> ${p.data}</p>
                   <p class="mb-1"><strong>Orario:</strong> ${p.orario_inizio} - ${p.orario_fine}</p>
                   <p class="mb-1"><strong>Sede:</strong> ${p.nome_sede}</p>
-                  <button class="btn btn-warning mt-auto btnModifica" data-id="${p.id}" data-data="${p.data}" data-inizio="${p.orario_inizio}" data-fine="${p.orario_fine}">Modifica</button>
                 </div>
               </div>
             </div>
@@ -146,34 +145,6 @@ $(document).ready(function () {
           $('#listaPrenotazioni').append(card);
         });
 
-        $('.btnModifica').click(function () {
-          const id = $(this).data('id');
-          const dataAttuale = $(this).data('data');
-          const inizioAttuale = $(this).data('inizio');
-          const fineAttuale = $(this).data('fine');
-
-          const nuovaData = prompt('Nuova data (YYYY-MM-DD)', dataAttuale);
-          if (!nuovaData) return;
-          const nuovoInizio = prompt('Nuovo orario di inizio (HH:MM)', inizioAttuale);
-          if (!nuovoInizio) return;
-          const nuovoFine = prompt('Nuovo orario di fine (HH:MM)', fineAttuale);
-          if (!nuovoFine) return;
-
-          $.ajax({
-            url: `http://localhost:3000/api/prenotazioni/${id}`,
-            method: 'PUT',
-            contentType: 'application/json',
-            headers: { Authorization: `Bearer ${token}` },
-            data: JSON.stringify({ data: nuovaData, orario_inizio: nuovoInizio, orario_fine: nuovoFine }),
-            success: function () {
-              $('#prenotazioneAlert').html('<div class="alert alert-success">Prenotazione aggiornata</div>');
-              caricaPrenotazioni();
-            },
-            error: function (xhr) {
-              $('#prenotazioneAlert').html(`<div class="alert alert-danger">${xhr.responseJSON?.message || 'Errore durante l\'aggiornamento'}</div>`);
-            }
-          });
-        });
       },
       error: function () {
         $('#listaPrenotazioni').html('<p class="text-center text-danger">Errore nel recupero delle prenotazioni</p>');


### PR DESCRIPTION
## Summary
- Redirect users to role-specific pages after login and hide the dashboard for admins and managers
- Move reservation editing to the dashboard and remove it from the booking menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f310ef9388328ad0e90bc75b7e07a