### PR TITLE
Fix booking payment insert and hide booking list

### DIFF
--- a/backend/controllers/prenotazioniController.js
+++ b/backend/controllers/prenotazioniController.js
@@ -22,7 +22,7 @@ exports.creaPrenotazione = async (req, res) => {
 
     // 2. Calcola importo da pagare
     const prezzoRes = await pool.query(
-      'SELECT prezzo_ora FROM spazi WHERE id = $1',
+      'SELECT prezzo_orario FROM spazi WHERE id = $1',
       [spazio_id]
     );
 
@@ -34,7 +34,7 @@ exports.creaPrenotazione = async (req, res) => {
     const start = new Date(`1970-01-01T${orario_inizio}`);
     const end = new Date(`1970-01-01T${orario_fine}`);
     const ore = (end - start) / (1000 * 60 * 60);
-    const importo = Number(prezzoRes.rows[0].prezzo_ora) * ore;
+    const importo = Number(prezzoRes.rows[0].prezzo_orario) * ore;
 
     // 3. Inserisci prenotazione
     const result = await pool.query(
@@ -45,8 +45,8 @@ exports.creaPrenotazione = async (req, res) => {
 
     // 4. Registra pagamento
     await pool.query(
-      `INSERT INTO pagamenti (prenotazione_id, importo, esito, timestamp)
-       VALUES ($1, $2, 'OK', NOW())`,
+      `INSERT INTO pagamenti (prenotazione_id, importo, timestamp)
+       VALUES ($1, $2, NOW())`,
       [result.rows[0].id, importo]
     );
 

--- a/database/README-db.md
+++ b/database/README-db.md
@@ -101,7 +101,6 @@ Dati relativi al pagamento associato a una prenotazione.
 | `id`              | SERIAL       | Identificativo del pagamento         |
 | `prenotazione_id` | INTEGER      | FK → `Prenotazione(id)`              |
 | `importo`         | NUMERIC(7,2) | Importo totale                       |
-| `esito`           | VARCHAR(10)  | Esito pagamento: `OK`, `KO`          |
 | `timestamp`       | TIMESTAMP    | Data e ora del pagamento             |
 
 ---
@@ -119,7 +118,7 @@ Dati relativi al pagamento associato a una prenotazione.
 ## 📌 Note
 
 - Le password vengono salvate in formato **hash** (es. con `bcrypt`)
-- I valori come `ruolo`, `tipo_spazio` ed `esito` sono validati con `CHECK(...)`
+- I valori come `ruolo` e `tipo_spazio` sono validati con `CHECK(...)`
 - Le chiavi esterne usano `ON DELETE CASCADE` per mantenere coerenza
 
 ---

--- a/database/er_coworkspace.drawio
+++ b/database/er_coworkspace.drawio
@@ -20,7 +20,7 @@
         <mxCell id="6" value="&lt;b&gt;Prenotazione&lt;/b&gt;&lt;br/&gt;id&lt;br/&gt;utente_id&lt;br/&gt;spazio_id&lt;br/&gt;data&lt;br/&gt;ora_inizio&lt;br/&gt;ora_fine" style="shape=swimlane;startSize=20;" vertex="1" parent="1">
           <mxGeometry x="280" y="160" width="160" height="25" as="geometry"/>
         </mxCell>
-        <mxCell id="7" value="&lt;b&gt;Pagamento&lt;/b&gt;&lt;br/&gt;id&lt;br/&gt;prenotazione_id&lt;br/&gt;importo&lt;br/&gt;esito&lt;br/&gt;timestamp" style="shape=swimlane;startSize=20;" vertex="1" parent="1">
+        <mxCell id="7" value="&lt;b&gt;Pagamento&lt;/b&gt;&lt;br/&gt;id&lt;br/&gt;prenotazione_id&lt;br/&gt;importo&lt;br/&gt;timestamp" style="shape=swimlane;startSize=20;" vertex="1" parent="1">
           <mxGeometry x="520" y="160" width="160" height="25" as="geometry"/>
         </mxCell>
       </root>

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -49,6 +49,5 @@ CREATE TABLE Pagamento (
   id SERIAL PRIMARY KEY,
   prenotazione_id INTEGER NOT NULL REFERENCES Prenotazione(id) ON DELETE CASCADE,
   importo NUMERIC(7,2) NOT NULL,
-  esito VARCHAR(10) CHECK (esito IN ('OK', 'KO')) NOT NULL,
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -15,8 +15,6 @@ $(document).ready(function () {
     window.location.href = "index.html";
   });
 
-  caricaPrenotazioni();
-
   // Cerca disponibilità spazi
   $('#formRicerca').submit(function (e) {
     e.preventDefault();
@@ -102,7 +100,6 @@ $(document).ready(function () {
               $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> confermata e pagamento di €${importo} effettuato!</div>`);
               $('#formRicerca')[0].reset();
               $('#risultatiSpazi').empty();
-              caricaPrenotazioni();
             },
             error: function (xhr) {
               $('#prenotazioneAlert').html(`<div class="alert alert-danger">❌ Errore: ${xhr.responseJSON?.message || 'Prenotazione fallita'}</div>`);
@@ -115,40 +112,4 @@ $(document).ready(function () {
       }
     });
   });
-  function caricaPrenotazioni() {
-    $('#listaPrenotazioni').empty();
-
-    $.ajax({
-      url: 'http://localhost:3000/api/prenotazioni',
-      method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
-      success: function (res) {
-        const prenotazioni = res.prenotazioni || [];
-        if (prenotazioni.length === 0) {
-          $('#listaPrenotazioni').html('<p class="text-center">Nessuna prenotazione</p>');
-          return;
-        }
-
-        prenotazioni.forEach(p => {
-          const card = `
-            <div class="col-md-4">
-              <div class="card h-100 shadow-sm">
-                <div class="card-body d-flex flex-column">
-                  <h5 class="card-title">${p.nome_spazio}</h5>
-                  <p class="mb-1"><strong>Data:</strong> ${p.data}</p>
-                  <p class="mb-1"><strong>Orario:</strong> ${p.orario_inizio} - ${p.orario_fine}</p>
-                  <p class="mb-1"><strong>Sede:</strong> ${p.nome_sede}</p>
-                </div>
-              </div>
-            </div>
-          `;
-          $('#listaPrenotazioni').append(card);
-        });
-
-      },
-      error: function () {
-        $('#listaPrenotazioni').html('<p class="text-center text-danger">Errore nel recupero delle prenotazioni</p>');
-      }
-    });
-  }
 });

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -49,9 +49,6 @@
 
     <div id="risultatiSpazi" class="row gy-4 justify-content-center"></div>
 
-    <h2 class="mt-5 text-center">Le tue prenotazioni</h2>
-    <div id="listaPrenotazioni" class="row gy-3 justify-content-center"></div>
-
     <button id="logoutBtn" class="btn btn-danger logout-bottom-right">Logout</button>
   </main>
 


### PR DESCRIPTION
## Summary
- Fix booking creation by using correct `prezzo_orario` column and computing total import
- Remove display of existing bookings on booking page and associated JS refresh
- Record payments without non-existent `esito` field and update database docs

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688f3363dd1c83289a586d300fe79a66