### PR TITLE
Add payment method selection for bookings

### DIFF
--- a/backend/README.txt
+++ b/backend/README.txt
@@ -80,7 +80,7 @@
 - POST   /api/prenotazioni              → Crea prenotazione
 
 💳 Pagamento:
-- POST   /api/pagamento                 → Simulazione pagamento
+- POST   /api/pagamento                 → Simulazione pagamento (utente_id, importo, metodo)
 
 🛠️ Admin:
 - GET    /api/admin/utenti              → Lista utenti

--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -2,17 +2,23 @@ const pool = require('../db');
 
 // 1. Registra pagamento
 exports.effettuaPagamento = async (req, res) => {
-  const { utente_id, importo } = req.body;
+  const { utente_id, importo, metodo } = req.body;
+
+  const metodiValidi = ['paypal', 'satispay', 'carta', 'bancomat'];
+  if (!metodiValidi.includes(metodo)) {
+    return res.status(400).json({ message: 'Metodo di pagamento non valido' });
+  }
 
   try {
     // Simulazione del pagamento
-    console.log(`💳 Pagamento simulato da utente ${utente_id}, importo €${importo}`);
+    console.log(`💳 Pagamento simulato da utente ${utente_id}, importo €${importo}, metodo ${metodo}`);
 
     res.status(200).json({
       message: 'Pagamento effettuato con successo (simulato)',
       pagamento: {
         utente_id,
         importo,
+        metodo,
         data: new Date().toISOString(),
         stato: 'successo'
       }

--- a/database/README-db.md
+++ b/database/README-db.md
@@ -101,6 +101,7 @@ Dati relativi al pagamento associato a una prenotazione.
 | `id`              | SERIAL       | Identificativo del pagamento         |
 | `prenotazione_id` | INTEGER      | FK → `Prenotazione(id)`              |
 | `importo`         | NUMERIC(7,2) | Importo totale                       |
+| `metodo`          | VARCHAR(20)  | Metodo usato (`paypal`, `satispay`, `carta`, `bancomat`) |
 | `timestamp`       | TIMESTAMP    | Data e ora del pagamento             |
 
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -49,5 +49,6 @@ CREATE TABLE Pagamento (
   id SERIAL PRIMARY KEY,
   prenotazione_id INTEGER NOT NULL REFERENCES Prenotazione(id) ON DELETE CASCADE,
   importo NUMERIC(7,2) NOT NULL,
+  metodo VARCHAR(20) NOT NULL CHECK (metodo IN ('paypal','satispay','carta','bancomat')),
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -53,7 +53,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint               | Descrizione                                      |
 |--------|------------------------|--------------------------------------------------|
-| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione                      |
+| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione con pagamento (richiede `metodo`) |
 | GET    | `/api/prenotazioni`    | Elenca tutte le prenotazioni dell’utente loggato|
 | DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione                         |
 
@@ -63,7 +63,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint            | Descrizione                            |
 |--------|---------------------|----------------------------------------|
-| POST   | `/api/pagamenti`    | Simula il pagamento di una prenotazione|
+| POST   | `/api/pagamento`    | Simula il pagamento (`utente_id`, `importo`, `metodo`)|
 
 ---
 

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -13,9 +13,10 @@ $(document).ready(function () {
     e.preventDefault();
 
     const importo = parseFloat($('#importo').val());
+    const metodo = $('#metodo').val();
 
-    if (isNaN(importo) || importo <= 0) {
-      $('#alertPagamento').html('<div class="alert alert-warning">Inserisci un importo valido.</div>');
+    if (isNaN(importo) || importo <= 0 || !metodo) {
+      $('#alertPagamento').html('<div class="alert alert-warning">Inserisci tutti i dati richiesti.</div>');
       return;
     }
 
@@ -28,7 +29,8 @@ $(document).ready(function () {
       },
       data: JSON.stringify({
         utente_id: utente.id,
-        importo: importo
+        importo: importo,
+        metodo: metodo
       }),
       success: function (res) {
         $('#alertPagamento').html(`<div class="alert alert-success">✅ ${res.message}</div>`);

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -91,6 +91,13 @@ $(document).ready(function () {
             return;
           }
 
+          const metodo_pagamento = prompt('Metodo di pagamento (paypal/satispay/carta/bancomat)?', 'paypal');
+          const metodiValidi = ['paypal', 'satispay', 'carta', 'bancomat'];
+          if (!metodo_pagamento || !metodiValidi.includes(metodo_pagamento.toLowerCase())) {
+            alert('Metodo di pagamento non valido');
+            return;
+          }
+
           $.ajax({
             url: 'http://localhost:3000/api/prenotazioni',
             method: 'POST',
@@ -101,10 +108,11 @@ $(document).ready(function () {
               spazio_id,
               data,
               orario_inizio,
-              orario_fine
+              orario_fine,
+              metodo_pagamento: metodo_pagamento.toLowerCase()
             }),
             success: function () {
-              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> confermata e pagamento di €${importo} effettuato!</div>`);
+              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> confermata e pagamento di €${importo} effettuato con ${metodo_pagamento}!</div>`);
               $('#formRicerca')[0].reset();
               $('#risultatiSpazi').empty();
             },

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -34,6 +34,15 @@
         <label for="importo" class="form-label">Importo (€)</label>
         <input type="number" step="0.01" min="0" id="importo" class="form-control" required />
       </div>
+      <div class="mb-3">
+        <label for="metodo" class="form-label">Metodo di pagamento</label>
+        <select id="metodo" class="form-select" required>
+          <option value="paypal">PayPal</option>
+          <option value="satispay">SatisPay</option>
+          <option value="carta">Carta di Credito</option>
+          <option value="bancomat">Bancomat</option>
+        </select>
+      </div>
       <button type="submit" class="btn btn-primary">Effettua Pagamento</button>
     </form>
 


### PR DESCRIPTION
## Summary
- allow choosing PayPal, SatisPay, credit card or Bancomat when booking a space
- store selected payment method in Pagamento records and document new API field
- update payment page to include method dropdown and validate submissions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f3fc0d86c83288df09b39ec3800e1