### PR TITLE
Add payment step for existing bookings

### DIFF
--- a/backend/README.txt
+++ b/backend/README.txt
@@ -80,7 +80,7 @@
 - POST   /api/prenotazioni              → Crea prenotazione
 
 💳 Pagamento:
-- POST   /api/pagamento                 → Simulazione pagamento
+- POST   /api/pagamento                 → Pagamento prenotazione (prenotazione_id, metodo)
 
 🛠️ Admin:
 - GET    /api/admin/utenti              → Lista utenti

--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -2,22 +2,55 @@ const pool = require('../db');
 
 // 1. Registra pagamento
 exports.effettuaPagamento = async (req, res) => {
-  const { utente_id, importo } = req.body;
+  const { prenotazione_id, metodo } = req.body;
+  const utente_id = req.utente.id;
+
+  const metodiValidi = ['paypal', 'satispay', 'carta', 'bancomat'];
+  if (!metodiValidi.includes(metodo)) {
+    return res.status(400).json({ message: 'Metodo di pagamento non valido' });
+  }
 
   try {
-    // Simulazione del pagamento
-    console.log(`💳 Pagamento simulato da utente ${utente_id}, importo €${importo}`);
+    await pool.query('BEGIN');
 
-    res.status(200).json({
-      message: 'Pagamento effettuato con successo (simulato)',
-      pagamento: {
-        utente_id,
-        importo,
-        data: new Date().toISOString(),
-        stato: 'successo'
-      }
+    // Recupera la prenotazione e verifica appartenenza all'utente
+    const prenRes = await pool.query(
+      'SELECT importo, utente_id FROM prenotazioni WHERE id = $1',
+      [prenotazione_id]
+    );
+
+    if (prenRes.rows.length === 0 || prenRes.rows[0].utente_id !== utente_id) {
+      await pool.query('ROLLBACK');
+      return res.status(404).json({ message: 'Prenotazione non trovata' });
+    }
+
+    // Controlla se esiste già un pagamento per questa prenotazione
+    const pagRes = await pool.query(
+      'SELECT id FROM pagamenti WHERE prenotazione_id = $1',
+      [prenotazione_id]
+    );
+
+    if (pagRes.rows.length > 0) {
+      await pool.query('ROLLBACK');
+      return res.status(400).json({ message: 'Prenotazione già pagata' });
+    }
+
+    const importo = prenRes.rows[0].importo;
+
+    await pool.query(
+      `INSERT INTO pagamenti (prenotazione_id, importo, metodo, timestamp)
+       VALUES ($1, $2, $3, NOW())`,
+      [prenotazione_id, importo, metodo]
+    );
+
+    await pool.query('COMMIT');
+
+    res.status(201).json({
+      message: 'Pagamento registrato',
+      pagamento: { prenotazione_id, importo, metodo }
     });
   } catch (err) {
+    await pool.query('ROLLBACK');
     console.error('Errore pagamento:', err);
     res.status(500).json({ message: 'Errore del server durante il pagamento' });
   }

--- a/database/README-db.md
+++ b/database/README-db.md
@@ -89,6 +89,7 @@ Rappresenta una prenotazione effettuata da un utente su uno spazio.
 | `data`        | DATE   | Data della prenotazione              |
 | `ora_inizio`  | TIME   | Ora di inizio                        |
 | `ora_fine`    | TIME   | Ora di fine                          |
+| `importo`     | NUMERIC(7,2) | Importo calcolato al momento della prenotazione |
 
 ---
 
@@ -101,6 +102,7 @@ Dati relativi al pagamento associato a una prenotazione.
 | `id`              | SERIAL       | Identificativo del pagamento         |
 | `prenotazione_id` | INTEGER      | FK → `Prenotazione(id)`              |
 | `importo`         | NUMERIC(7,2) | Importo totale                       |
+| `metodo`          | VARCHAR(20)  | Metodo usato (`paypal`, `satispay`, `carta`, `bancomat`) |
 | `timestamp`       | TIMESTAMP    | Data e ora del pagamento             |
 
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -41,7 +41,8 @@ CREATE TABLE Prenotazione (
   spazio_id INTEGER NOT NULL REFERENCES Spazio(id) ON DELETE CASCADE,
   data DATE NOT NULL,
   ora_inizio TIME NOT NULL,
-  ora_fine TIME NOT NULL
+  ora_fine TIME NOT NULL,
+  importo NUMERIC(7,2) NOT NULL
 );
 
 -- Pagamento
@@ -49,5 +50,6 @@ CREATE TABLE Pagamento (
   id SERIAL PRIMARY KEY,
   prenotazione_id INTEGER NOT NULL REFERENCES Prenotazione(id) ON DELETE CASCADE,
   importo NUMERIC(7,2) NOT NULL,
+  metodo VARCHAR(20) NOT NULL CHECK (metodo IN ('paypal','satispay','carta','bancomat')),
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -53,7 +53,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint               | Descrizione                                      |
 |--------|------------------------|--------------------------------------------------|
-| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione                      |
+| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione (restituisce l'importo da pagare) |
 | GET    | `/api/prenotazioni`    | Elenca tutte le prenotazioni dell’utente loggato|
 | DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione                         |
 
@@ -63,7 +63,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint            | Descrizione                            |
 |--------|---------------------|----------------------------------------|
-| POST   | `/api/pagamenti`    | Simula il pagamento di una prenotazione|
+| POST   | `/api/pagamento`    | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) |
 
 ---
 

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -8,31 +8,56 @@ $(document).ready(function () {
     return;
   }
 
+  // Carica prenotazioni non ancora pagate
+  $.ajax({
+    url: 'http://localhost:3000/api/prenotazioni',
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+    success: function (res) {
+      const prenotazioni = (res.prenotazioni || []).filter(p => !p.pagamento_id);
+
+      if (prenotazioni.length === 0) {
+        $('#alertPagamento').html('<div class="alert alert-info">Nessuna prenotazione da pagare.</div>');
+        $('#formPagamento').hide();
+        return;
+      }
+
+      prenotazioni.forEach(p => {
+        const testo = `#${p.id} - ${p.nome_spazio} ${p.data} ${p.ora_inizio}-${p.ora_fine} (€${parseFloat(p.importo).toFixed(2)})`;
+        $('#prenotazione').append(`<option value="${p.id}" data-importo="${p.importo}">${testo}</option>`);
+      });
+
+      $('#prenotazione').change(function () {
+        const imp = $('#prenotazione option:selected').data('importo');
+        $('#importoDaPagare').text(`Importo: €${parseFloat(imp).toFixed(2)}`);
+      }).trigger('change');
+    },
+    error: function () {
+      $('#alertPagamento').html('<div class="alert alert-danger">Errore nel recupero delle prenotazioni.</div>');
+    }
+  });
+
   // Gestione submit form pagamento
   $('#formPagamento').submit(function (e) {
     e.preventDefault();
 
-    const importo = parseFloat($('#importo').val());
-
-    if (isNaN(importo) || importo <= 0) {
-      $('#alertPagamento').html('<div class="alert alert-warning">Inserisci un importo valido.</div>');
-      return;
-    }
+    const prenotazione_id = parseInt($('#prenotazione').val());
+    const metodo = $('#metodo').val();
 
     $.ajax({
       url: 'http://localhost:3000/api/pagamento',
       method: 'POST',
       contentType: 'application/json',
-      headers: {
-        Authorization: `Bearer ${token}`
-      },
-      data: JSON.stringify({
-        utente_id: utente.id,
-        importo: importo
-      }),
+      headers: { Authorization: `Bearer ${token}` },
+      data: JSON.stringify({ prenotazione_id, metodo }),
       success: function (res) {
         $('#alertPagamento').html(`<div class="alert alert-success">✅ ${res.message}</div>`);
+        $('#prenotazione option:selected').remove();
         $('#formPagamento')[0].reset();
+        $('#importoDaPagare').empty();
+        if ($('#prenotazione option').length === 0) {
+          $('#formPagamento').hide();
+        }
       },
       error: function (xhr) {
         $('#alertPagamento').html(`<div class="alert alert-danger">❌ ${xhr.responseJSON?.message || 'Errore nel pagamento'}</div>`);

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -104,7 +104,7 @@ $(document).ready(function () {
               orario_fine
             }),
             success: function () {
-              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> confermata e pagamento di €${importo} effettuato!</div>`);
+              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> registrata. Importo da pagare: €${importo}.</div>`);
               $('#formRicerca')[0].reset();
               $('#risultatiSpazi').empty();
             },

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -31,9 +31,19 @@
 
     <form id="formPagamento" class="mb-3">
       <div class="mb-3">
-        <label for="importo" class="form-label">Importo (€)</label>
-        <input type="number" step="0.01" min="0" id="importo" class="form-control" required />
+        <label for="prenotazione" class="form-label">Prenotazione</label>
+        <select id="prenotazione" class="form-select" required></select>
       </div>
+      <div class="mb-3">
+        <label for="metodo" class="form-label">Metodo di pagamento</label>
+        <select id="metodo" class="form-select" required>
+          <option value="paypal">PayPal</option>
+          <option value="satispay">SatisPay</option>
+          <option value="carta">Carta di Credito</option>
+          <option value="bancomat">Bancomat</option>
+        </select>
+      </div>
+      <p id="importoDaPagare" class="fw-bold"></p>
       <button type="submit" class="btn btn-primary">Effettua Pagamento</button>
     </form>
 


### PR DESCRIPTION
## Summary
- store booking price and remove payment from reservation flow
- let users pick an existing booking and pay with PayPal, SatisPay, card or Bancomat
- document new booking and payment APIs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f3fc0d86c83288df09b39ec3800e1