### PR TITLE
Calcola e memorizza importo prenotazione

### DIFF
--- a/backend/README.txt
+++ b/backend/README.txt
@@ -77,10 +77,10 @@
 - POST   /api/disponibilita/ricerca     → Ricerca spazi disponibili
 
 📆 Prenotazioni:
-- POST   /api/prenotazioni              → Crea prenotazione
+  - POST   /api/prenotazioni              → Crea prenotazione (l'utente è dedotto dal token, l'importo è calcolato)
 
 💳 Pagamento:
-- POST   /api/pagamento                 → Pagamento prenotazione (prenotazione_id, metodo)
+  - POST   /api/pagamento                 → Pagamento prenotazione (`prenotazione_id`, `metodo`; importo letto dalla prenotazione)
 
 🛠️ Admin:
 - GET    /api/admin/utenti              → Lista utenti

--- a/backend/controllers/prenotazioniController.js
+++ b/backend/controllers/prenotazioniController.js
@@ -2,7 +2,8 @@ const pool = require('../db');
 
 // ✅ Crea una prenotazione e calcola l'importo da pagare
 exports.creaPrenotazione = async (req, res) => {
-  const { utente_id, spazio_id, data, orario_inizio, orario_fine } = req.body;
+  const { spazio_id, data, orario_inizio, orario_fine } = req.body;
+  const utente_id = req.utente.id;
 
   try {
     await pool.query('BEGIN');
@@ -38,9 +39,9 @@ exports.creaPrenotazione = async (req, res) => {
 
     // 3. Inserisci prenotazione
     const result = await pool.query(
-      `INSERT INTO prenotazioni (utente_id, spazio_id, data, orario_inizio, orario_fine)
-       VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-      [utente_id, spazio_id, data, orario_inizio, orario_fine]
+      `INSERT INTO prenotazioni (utente_id, spazio_id, data, orario_inizio, orario_fine, importo)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [utente_id, spazio_id, data, orario_inizio, orario_fine, importo]
     );
 
     await pool.query('COMMIT');

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -53,9 +53,11 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint               | Descrizione                                      |
 |--------|------------------------|--------------------------------------------------|
-| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione (restituisce l'importo da pagare) |
+| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione (calcola e restituisce l'importo) |
 | GET    | `/api/prenotazioni`    | Elenca tutte le prenotazioni dell’utente loggato|
 | DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione                         |
+
+**Body POST /api/prenotazioni:** `spazio_id`, `data`, `orario_inizio`, `orario_fine`
 
 ---
 
@@ -63,7 +65,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint            | Descrizione                            |
 |--------|---------------------|----------------------------------------|
-| POST   | `/api/pagamento`    | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) |
+| POST   | `/api/pagamento`    | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) – l'importo è letto dalla prenotazione |
 
 
 ---

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -91,14 +91,15 @@ $(document).ready(function () {
             contentType: 'application/json',
             headers: { Authorization: `Bearer ${token}` },
             data: JSON.stringify({
-              utente_id: utente.id,
               spazio_id,
               data,
               orario_inizio,
               orario_fine
             }),
-            success: function () {
-              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> registrata!</div>`);
+            success: function (res) {
+              const importo = parseFloat(res.prenotazione?.importo);
+              const msgImporto = isNaN(importo) ? '' : ` Importo: €${importo.toFixed(2)}`;
+              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> registrata!${msgImporto}</div>`);
               $('#formRicerca')[0].reset();
               $('#risultatiSpazi').empty();
             },


### PR DESCRIPTION
## Summary
- Inserito l'importo calcolato direttamente nella query di creazione delle prenotazioni usando l'ID utente dal token
- Eliminato l'invio di `utente_id` dal client e mostrato l'importo di conferma ricevuto dall'API
- Aggiornata la documentazione per chiarire campi richiesti e uso dell'importo nel pagamento

## Testing
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_688f4a4399b483289b3482ed46673260