### PR TITLE
Handle unpaid reservations backend

### DIFF
--- a/backend/controllers/prenotazioniController.js
+++ b/backend/controllers/prenotazioniController.js
@@ -125,3 +125,26 @@ exports.modificaPrenotazione = async (req, res) => {
     res.status(500).json({ message: 'Errore del server' });
   }
 };
+
+// ✅ Recupera prenotazioni dell'utente non ancora pagate
+exports.prenotazioniNonPagate = async (req, res) => {
+  const utente_id = req.utente.id;
+
+  try {
+    const result = await pool.query(
+      `SELECT p.*, s.nome AS nome_spazio, sede.nome AS nome_sede, pag.id AS pagamento_id
+       FROM prenotazioni p
+       JOIN spazi s ON p.spazio_id = s.id
+       JOIN sedi sede ON s.sede_id = sede.id
+       LEFT JOIN pagamenti pag ON pag.prenotazione_id = p.id
+       WHERE p.utente_id = $1 AND (pag.id IS NULL OR pag.id = 0)
+       ORDER BY data, orario_inizio`,
+      [utente_id]
+    );
+
+    res.json({ prenotazioni: result.rows });
+  } catch (err) {
+    console.error('Errore recupero prenotazioni non pagate:', err);
+    res.status(500).json({ message: 'Errore del server' });
+  }
+};

--- a/backend/routes/prenotazioniRoutes.js
+++ b/backend/routes/prenotazioniRoutes.js
@@ -9,6 +9,9 @@ router.post('/prenotazioni', verificaToken, prenotazioniController.creaPrenotazi
 // ✅ Visualizza prenotazioni dell'utente autenticato
 router.get('/prenotazioni', verificaToken, prenotazioniController.visualizzaPrenotazioni);
 
+// ✅ Prenotazioni dell'utente non ancora pagate
+router.get('/prenotazioni/non-pagate', verificaToken, prenotazioniController.prenotazioniNonPagate);
+
 // ✅ Modifica una prenotazione esistente
 router.put('/prenotazioni/:id', verificaToken, prenotazioniController.modificaPrenotazione);
 

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -10,15 +10,15 @@ $(document).ready(function () {
 
   // Carica prenotazioni non ancora pagate
   $.ajax({
-    url: 'http://localhost:3000/api/prenotazioni',
+    url: 'http://localhost:3000/api/prenotazioni/non-pagate',
     method: 'GET',
     headers: { Authorization: `Bearer ${token}` },
     success: function (res) {
-      // Mostra solo le prenotazioni non ancora pagate. In alcuni casi
-      // pagamento_id può essere undefined oppure 0: controlliamo
-      // esplicitamente valori nulli/undefined.
+      // Il backend ritorna solo prenotazioni senza pagamento ma, per
+      // maggiore robustezza, filtriamo eventuali casi anomali in cui
+      // pagamento_id sia undefined oppure 0.
       const prenotazioni = (res.prenotazioni || []).filter(
-        p => p.pagamento_id == null
+        p => !p.pagamento_id
       );
 
       if (prenotazioni.length === 0) {


### PR DESCRIPTION
## Summary
- expand payment filtering to include `pagamento_id` equal to 0 and call a backend endpoint
- add backend endpoint `/prenotazioni/non-pagate` to serve unpaid bookings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f4b5e83a88328978ba4a15029c517