### PR TITLE
Fix price column name for bookings

### DIFF
--- a/backend/controllers/disponibilitaController.js
+++ b/backend/controllers/disponibilitaController.js
@@ -22,7 +22,7 @@ exports.ricercaDisponibilita = async (req, res) => {
 
   try {
     const result = await pool.query(`
-      SELECT s.id AS spazio_id, s.nome AS nome_spazio, s.descrizione, s.prezzo_orario, sede.nome AS nome_sede
+      SELECT s.id AS spazio_id, s.nome AS nome_spazio, s.descrizione, s.prezzo_ora AS prezzo_orario, sede.nome AS nome_sede
       FROM spazi s
       JOIN sedi sede ON s.sede_id = sede.id
       WHERE s.id NOT IN (

--- a/backend/controllers/gestoreController.js
+++ b/backend/controllers/gestoreController.js
@@ -22,7 +22,7 @@ exports.aggiungiSpazio = async (req, res) => {
 
   try {
     const result = await pool.query(
-      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_ora, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
       [sede_id, nome, descrizione, prezzo_orario, capienza]
     );
     res.status(201).json({ spazio: result.rows[0] });

--- a/backend/controllers/prenotazioniController.js
+++ b/backend/controllers/prenotazioniController.js
@@ -24,7 +24,7 @@ exports.creaPrenotazione = async (req, res) => {
 
     // 2. Calcola importo da pagare
     const prezzoRes = await pool.query(
-      'SELECT prezzo_orario FROM spazi WHERE id = $1',
+      'SELECT prezzo_ora AS prezzo_orario FROM spazi WHERE id = $1',
       [spazio_id]
     );
 
@@ -133,7 +133,7 @@ exports.prenotazioniNonPagate = async (req, res) => {
 
   try {
     const result = await pool.query(
-      `SELECT p.*, s.nome AS nome_spazio, s.prezzo_orario, sede.nome AS nome_sede, pag.id AS pagamento_id
+      `SELECT p.*, s.nome AS nome_spazio, s.prezzo_ora AS prezzo_orario, sede.nome AS nome_sede, pag.id AS pagamento_id
        FROM prenotazioni p
        JOIN spazi s ON p.spazio_id = s.id
        JOIN sedi sede ON s.sede_id = sede.id

--- a/backend/controllers/spaziController.js
+++ b/backend/controllers/spaziController.js
@@ -22,7 +22,7 @@ exports.aggiungiSpazio = async (req, res) => {
 
   try {
     const result = await pool.query(
-      `INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) 
+      `INSERT INTO spazi (sede_id, nome, descrizione, prezzo_ora, capienza) 
        VALUES ($1, $2, $3, $4, $5) RETURNING *`,
       [sede_id, nome, descrizione, prezzo_orario, capienza]
     );


### PR DESCRIPTION
## Summary
- Correct price column name (`prezzo_ora`) in booking creation and retrieval
- Adjust availability and space creation queries to use `prezzo_ora`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f507d872483288a493b9b09958ca9