### PR TITLE
Use prezzo_ora alias in pagamenti controller

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -33,7 +33,7 @@ exports.effettuaPagamento = async (req, res) => {
     const orario_fine = prenRes.rows[0].orario_fine;
 
     const prezzoRes = await pool.query(
-      'SELECT prezzo_orario FROM spazi WHERE id = $1',
+      'SELECT prezzo_ora AS prezzo_orario FROM spazi WHERE id = $1',
       [spazio_id]
     );
     if (prezzoRes.rows.length === 0) {


### PR DESCRIPTION
## Summary
- fix pagamenti controller to select `prezzo_ora` with alias `prezzo_orario` when computing payment amount

## Testing
- `npm test` (fails: no test specified)
- `timeout 5 npm start` (fails: DB_USER is missing)


------
https://chatgpt.com/codex/tasks/task_e_688f5b9c4e208328b4a1209255ea91f5