### PR TITLE
Add profile management page

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -12,6 +12,7 @@ $(document).ready(function () {
 
     // Link comuni a tutti gli utenti autenticati
     menu.append('<li class="nav-item"><a class="nav-link" href="sedi.html">Sedi</a></li>');
+    menu.append('<li class="nav-item"><a class="nav-link" href="profilo.html">Profilo</a></li>');
 
     // Link specifici per ruolo
     if (ruolo === 'cliente') {

--- a/frontend/js/profilo.js
+++ b/frontend/js/profilo.js
@@ -1,0 +1,35 @@
+$(document).ready(function () {
+  const token = localStorage.getItem('token');
+  const utente = JSON.parse(localStorage.getItem('utente') || 'null');
+
+  if (!token || !utente) {
+    window.location.href = 'index.html';
+    return;
+  }
+
+  $('#profiloForm').submit(function (e) {
+    e.preventDefault();
+    const nome = $('#nuovoNome').val();
+    const password = $('#nuovaPassword').val();
+
+    $.ajax({
+      url: 'http://localhost:3000/api/utente/me',
+      method: 'PUT',
+      contentType: 'application/json',
+      headers: { Authorization: `Bearer ${token}` },
+      data: JSON.stringify({ nome, password }),
+      success: function () {
+        $('#profiloAlert').html('<div class="alert alert-success">Profilo aggiornato</div>');
+        if (nome) {
+          utente.nome = nome;
+          localStorage.setItem('utente', JSON.stringify(utente));
+          $('#nomeUtente').text(nome);
+        }
+        $('#profiloForm')[0].reset();
+      },
+      error: function (xhr) {
+        $('#profiloAlert').html(`<div class="alert alert-danger">${xhr.responseJSON?.message || 'Errore durante l\'aggiornamento'}</div>`);
+      }
+    });
+  });
+});

--- a/frontend/profilo.html
+++ b/frontend/profilo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <title>CoWorkSpace - Profilo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="css/style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
+    <div class="container d-flex align-items-center">
+      <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
+      <div class="d-flex align-items-center text-white ms-3">
+        <span id="nomeUtente" class="fw-bold"></span>
+        <span id="ruoloUtente" class="ms-2 fst-italic"></span>
+      </div>
+      <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+        <ul id="menuLinks" class="navbar-nav gap-3"></ul>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container my-5" style="max-width: 500px;">
+    <h2 class="mb-4">Aggiorna Profilo</h2>
+    <div id="profiloAlert"></div>
+    <form id="profiloForm">
+      <div class="mb-3">
+        <label for="nuovoNome" class="form-label">Nuovo Nome</label>
+        <input type="text" id="nuovoNome" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label for="nuovaPassword" class="form-label">Nuova Password</label>
+        <input type="password" id="nuovaPassword" class="form-control" />
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Aggiorna</button>
+    </form>
+  </main>
+
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/menu.js"></script>
+  <script src="js/profilo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add profile page with form for updating user name and password
- create client script to send profile update requests
- link profile page from menu for signed-in users

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6716e39c8328ac3df2f243f323c9