### PR TITLE
Rename prezzo_ora field and drop prenotazioni importo

### DIFF
--- a/backend/controllers/gestoreController.js
+++ b/backend/controllers/gestoreController.js
@@ -22,7 +22,7 @@ exports.aggiungiSpazio = async (req, res) => {
 
   try {
     const result = await pool.query(
-      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_ora, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
       [sede_id, nome, descrizione, prezzo_orario, capienza]
     );
     res.status(201).json({ spazio: result.rows[0] });
@@ -69,7 +69,7 @@ exports.aggiungiDisponibilita = async (req, res) => {
 
   try {
     const result = await pool.query(
-      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_ora, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
       [id, data, orario_inizio, orario_fine]
     );
     res.status(201).json({ disponibilita: result.rows[0] });

--- a/backend/controllers/spaziController.js
+++ b/backend/controllers/spaziController.js
@@ -22,7 +22,7 @@ exports.aggiungiSpazio = async (req, res) => {
 
   try {
     const result = await pool.query(
-      `INSERT INTO spazi (sede_id, nome, descrizione, prezzo_ora, capienza) 
+      `INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) 
        VALUES ($1, $2, $3, $4, $5) RETURNING *`,
       [sede_id, nome, descrizione, prezzo_orario, capienza]
     );

--- a/database/README-db.md
+++ b/database/README-db.md
@@ -59,7 +59,7 @@ Definisce un'unità prenotabile all'interno di una sede (es. sala, scrivania, uf
 | `sede_id`     | INTEGER      | FK → `Sede(id)`                          |
 | `tipo_spazio` | VARCHAR(20)  | Tipo: `scrivania`, `ufficio`, `sala`     |
 | `servizi`     | TEXT         | Servizi inclusi (es. WiFi, stampante)    |
-| `prezzo_ora`  | NUMERIC(6,2) | Prezzo orario dello spazio               |
+| `prezzo_orario`  | NUMERIC(6,2) | Prezzo orario dello spazio               |
 
 ---
 
@@ -89,7 +89,6 @@ Rappresenta una prenotazione effettuata da un utente su uno spazio.
 | `data`        | DATE   | Data della prenotazione              |
 | `orario_inizio`  | TIME   | Ora di inizio                        |
 | `orario_fine`    | TIME   | Ora di fine                          |
-| `importo`     | NUMERIC(7,2) | Importo calcolato al momento della prenotazione |
 
 ---
 

--- a/database/migrations/001_rename_prezzo_ora_and_drop_importo.sql
+++ b/database/migrations/001_rename_prezzo_ora_and_drop_importo.sql
@@ -1,0 +1,6 @@
+-- Migration: rename prezzo_ora to prezzo_orario and drop importo from prenotazioni
+ALTER TABLE IF EXISTS spazi
+    RENAME COLUMN prezzo_ora TO prezzo_orario;
+
+ALTER TABLE IF EXISTS prenotazioni
+    DROP COLUMN IF EXISTS importo;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE spazi (
   sede_id INTEGER NOT NULL REFERENCES sedi(id) ON DELETE CASCADE,
   tipo_spazio VARCHAR(20) CHECK (tipo_spazio IN ('scrivania', 'ufficio', 'sala')) NOT NULL,
   servizi TEXT,
-  prezzo_ora NUMERIC(6,2) NOT NULL
+  prezzo_orario NUMERIC(6,2) NOT NULL
 );
 
 -- Disponibilita
@@ -41,8 +41,7 @@ CREATE TABLE prenotazioni (
   spazio_id INTEGER NOT NULL REFERENCES spazi(id) ON DELETE CASCADE,
   data DATE NOT NULL,
   orario_inizio TIME NOT NULL,
-  orario_fine TIME NOT NULL,
-  importo NUMERIC(7,2) NOT NULL
+  orario_fine TIME NOT NULL
 );
 
 -- Pagamenti


### PR DESCRIPTION
## Summary
- Rename `prezzo_ora` to `prezzo_orario` in schema and controllers and document change
- Remove unused `importo` from `prenotazioni` table and related docs
- Add migration script to rename price column and drop obsolete `importo`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8bb266648328b7c37a88f4c23f52