### PR TITLE
feat: allow users to delete own bookings

### DIFF
--- a/backend/README.txt
+++ b/backend/README.txt
@@ -78,6 +78,9 @@
 
 📆 Prenotazioni:
   - POST   /api/prenotazioni              → Crea prenotazione (l'utente è dedotto dal token, l'importo è calcolato)
+  - GET    /api/prenotazioni              → Prenotazioni utente
+  - PUT    /api/prenotazioni/:id          → Modifica prenotazione
+  - DELETE /api/prenotazioni/:id          → Annulla prenotazione (solo proprietario)
 
 💳 Pagamento:
   - POST   /api/pagamento                 → Pagamento prenotazione (`prenotazione_id`, `metodo`; importo letto dalla prenotazione)

--- a/backend/controllers/prenotazioniController.js
+++ b/backend/controllers/prenotazioniController.js
@@ -149,3 +149,25 @@ exports.prenotazioniNonPagate = async (req, res) => {
     res.status(500).json({ message: 'Errore del server' });
   }
 };
+
+// ✅ Elimina una prenotazione dell'utente
+exports.eliminaPrenotazione = async (req, res) => {
+  const { id } = req.params;
+  const utente_id = req.utente.id;
+
+  try {
+    const result = await pool.query(
+      'DELETE FROM prenotazioni WHERE id = $1 AND utente_id = $2 RETURNING id',
+      [id, utente_id]
+    );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ message: 'Prenotazione non trovata' });
+    }
+
+    res.json({ message: 'Prenotazione eliminata' });
+  } catch (err) {
+    console.error('Errore eliminazione prenotazione:', err);
+    res.status(500).json({ message: 'Errore del server' });
+  }
+};

--- a/backend/routes/prenotazioniRoutes.js
+++ b/backend/routes/prenotazioniRoutes.js
@@ -15,4 +15,7 @@ router.get('/prenotazioni/non-pagate', verificaToken, prenotazioniController.pre
 // ✅ Modifica una prenotazione esistente
 router.put('/prenotazioni/:id', verificaToken, prenotazioniController.modificaPrenotazione);
 
+// ✅ Elimina una prenotazione esistente
+router.delete('/prenotazioni/:id', verificaToken, prenotazioniController.eliminaPrenotazione);
+
 module.exports = router;

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -69,11 +69,12 @@ Filtri disponibili su `/api/sedi`:
 |--------|------------------------|--------------------------------------------------|
 | POST   | `/api/prenotazioni`    | Crea una nuova prenotazione (calcola e restituisce l'importo) |
 | GET    | `/api/prenotazioni`    | Elenca tutte le prenotazioni dell’utente loggato|
-| DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione                         |
+| DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione dell’utente loggato     |
 
 **Body POST /api/prenotazioni:** `spazio_id`, `data`, `orario_inizio`, `orario_fine`
 
 > **Nota di sicurezza:** l'ID dell'utente viene dedotto dal token di autenticazione e non va inviato nel body. Qualsiasi `utente_id` manipolato o incluso nella richiesta viene ignorato e la prenotazione sarà sempre associata all'utente autenticato.
+> Solo il proprietario può modificare o eliminare la propria prenotazione.
 
 ---
 

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -51,6 +51,7 @@ $(document).ready(function () {
               <div class="mt-2 mt-md-0 d-flex flex-column flex-md-row align-items-md-center">
                 ⏰ <strong>Orario:</strong> ${oraInizio} - ${oraFine}
                 <button class="btn btn-sm btn-warning ms-md-3 mt-2 mt-md-0 btnModifica" data-id="${p.id}" data-data="${p.data}" data-inizio="${p.orario_inizio}" data-fine="${p.orario_fine}">Modifica</button>
+                <button class="btn btn-sm btn-danger ms-md-2 mt-2 mt-md-0 btnElimina" data-id="${p.id}">Elimina</button>
               </div>
             </li>
           `);
@@ -81,6 +82,24 @@ $(document).ready(function () {
             },
             error: function (xhr) {
               $('#dashboardAlert').html(`<div class="alert alert-danger">${xhr.responseJSON?.message || 'Errore durante l\'aggiornamento'}</div>`);
+            }
+          });
+        });
+
+        $('.btnElimina').click(function () {
+          const id = $(this).data('id');
+          if (!confirm('Sei sicuro di voler annullare questa prenotazione?')) return;
+
+          $.ajax({
+            url: `http://localhost:3000/api/prenotazioni/${id}`,
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}` },
+            success: function () {
+              $('#dashboardAlert').html('<div class="alert alert-success">Prenotazione eliminata</div>');
+              caricaPrenotazioni();
+            },
+            error: function (xhr) {
+              $('#dashboardAlert').html(`<div class="alert alert-danger">${xhr.responseJSON?.message || 'Errore durante l\'eliminazione'}</div>`);
             }
           });
         });


### PR DESCRIPTION
## Summary
- add DELETE `/prenotazioni/:id` route and controller to let users remove their own booking
- document new endpoint and expose a delete action in the dashboard UI
- refresh backend README and API docs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8f1180008328b14551f36c22fa68