### PR TITLE
feat: enhance booking page with modal and spinner

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -147,6 +147,7 @@ h1.main-title {
   flex-direction: column;
   border-radius: 12px;
   box-shadow: 0 8px 30px rgba(0,0,0,0.1);
+  overflow: hidden;
 }
 
 #risultatiSpazi .card:hover {
@@ -409,8 +410,35 @@ button.btn-lg {
   margin-bottom: 1.5rem;
 }
 
-#riepilogoContainer .card {
+  #riepilogoContainer .card {
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   border-radius: 12px;
   margin-bottom: 10px;
+}
+
+.spazio-img {
+  height: 160px;
+  object-fit: cover;
+}
+
+.card-icons i {
+  margin-right: 0.5rem;
+  font-size: 1.2rem;
+}
+
+.btnPrenota {
+  font-weight: 700;
+}
+
+#loadingSpinner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255,255,255,0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
 }

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -14,8 +14,16 @@ $(document).ready(function () {
     window.location.href = "index.html";
   });
 
+  function showSpinner() {
+    $('#loadingSpinner').show();
+  }
+
+  function hideSpinner() {
+    $('#loadingSpinner').hide();
+  }
+
   // Cerca disponibilità spazi
-  $('#formRicerca').submit(function (e) {
+  $('#formRicerca').submit(async function (e) {
     e.preventDefault();
 
     const data = $('#data').val();
@@ -35,86 +43,105 @@ $(document).ready(function () {
     $('#prenotazioneAlert').empty();
     $('#risultatiSpazi').empty();
 
-    $.ajax({
-      url: 'http://localhost:3000/api/disponibilita',
-      method: 'POST',
-      contentType: 'application/json',
-      headers: { Authorization: `Bearer ${token}` },
-      data: JSON.stringify({ data, orario_inizio, orario_fine }),
-      success: function (response) {
-        const spazi = response.risultati || [];
-        if (spazi.length === 0) {
-          $('#prenotazioneAlert').html('<div class="alert alert-warning">Nessuno spazio disponibile per l\'orario selezionato.</div>');
-          return;
-        }
+    showSpinner();
 
-        spazi.forEach(spazio => {
-          const prezzo = parseFloat(spazio.prezzo_orario);
-          const prezzoFormattato = isNaN(prezzo) ? "N/A" : prezzo.toFixed(2);
+    try {
+      const res = await fetch('http://localhost:3000/api/disponibilita', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ data, orario_inizio, orario_fine })
+      });
+      if (!res.ok) throw new Error();
+      const response = await res.json();
+      const spazi = response.risultati || [];
 
-          // Calcolo prezzo totale per la fascia oraria selezionata
-          const start = new Date(`1970-01-01T${orario_inizio}:00`);
-          const end = new Date(`1970-01-01T${orario_fine}:00`);
-          const ore = (end - start) / (1000 * 60 * 60);
-          const prezzoTotale = isNaN(prezzo) ? "N/A" : (prezzo * ore).toFixed(2);
+      if (spazi.length === 0) {
+        $('#prenotazioneAlert').html('<div class="alert alert-warning">Nessuno spazio disponibile per l\'orario selezionato.</div>');
+        hideSpinner();
+        return;
+      }
 
-          const card = `
-            <div class="col-md-4 mb-3">
-              <div class="card h-100 shadow-sm">
-                <div class="card-body d-flex flex-column">
-                  <h5 class="card-title">${spazio.nome_spazio}</h5>
-                  <p class="card-text flex-grow-1">${spazio.descrizione}</p>
-                  <p class="mb-1"><strong>Sede:</strong> ${spazio.nome_sede}</p>
-                  <p><strong>Prezzo orario:</strong> €${prezzoFormattato}</p>
-                  <p><strong>Prezzo totale per la fascia selezionata:</strong> €${prezzoTotale}</p>
-                  <button class="btn btn-success mt-auto btnPrenota" data-id="${spazio.spazio_id}" data-nome="${spazio.nome_spazio}" data-prezzo="${prezzo}">Prenota</button>
+      spazi.forEach(spazio => {
+        const prezzo = parseFloat(spazio.prezzo_orario);
+        const prezzoFormattato = isNaN(prezzo) ? "N/A" : prezzo.toFixed(2);
+
+        const start = new Date(`1970-01-01T${orario_inizio}:00`);
+        const end = new Date(`1970-01-01T${orario_fine}:00`);
+        const ore = (end - start) / (1000 * 60 * 60);
+        const prezzoTotale = isNaN(prezzo) ? "N/A" : (prezzo * ore).toFixed(2);
+
+        const card = `
+          <div class="col-md-4 mb-3">
+            <div class="card h-100 shadow-sm">
+              <img src="https://via.placeholder.com/600x400?text=${encodeURIComponent(spazio.nome_spazio)}" class="spazio-img card-img-top" alt="${spazio.nome_spazio}">
+              <div class="card-body d-flex flex-column">
+                <h5 class="card-title">${spazio.nome_spazio}</h5>
+                <p class="card-text flex-grow-1">${spazio.descrizione}</p>
+                <div class="card-icons text-primary mb-2">
+                  <i class="bi bi-wifi"></i><i class="bi bi-cup-hot"></i><i class="bi bi-people"></i>
                 </div>
+                <p class="mb-1"><i class="bi bi-geo-alt-fill me-1"></i><strong>Sede:</strong> ${spazio.nome_sede}</p>
+                <p class="mb-1"><strong>Prezzo orario:</strong> €${prezzoFormattato}</p>
+                <p><strong>Prezzo totale per la fascia selezionata:</strong> €${prezzoTotale}</p>
+                <button class="btn btn-primary btn-lg mt-auto w-100 btnPrenota" data-id="${spazio.spazio_id}" data-nome="${spazio.nome_spazio}">Prenota</button>
               </div>
             </div>
-          `;
-          $('#risultatiSpazi').append(card);
-        });
+          </div>
+        `;
+        $('#risultatiSpazi').append(card);
+      });
 
-        // Click su Prenota
-        $('.btnPrenota').click(function () {
-          const spazio_id = $(this).data('id');
-          const nome_spazio = $(this).data('nome');
+      hideSpinner();
 
-          if (!confirm(`Confermi la prenotazione di ${nome_spazio}?`)) {
-            return;
-          }
+      $('.btnPrenota').click(function () {
+        const spazio_id = $(this).data('id');
+        const nome_spazio = $(this).data('nome');
+        $('#confirmModalBody').text(`Confermi la prenotazione di ${nome_spazio}?`);
+        $('#confirmModal').data('spazio', { id: spazio_id, nome: nome_spazio });
+        const modal = new bootstrap.Modal(document.getElementById('confirmModal'));
+        modal.show();
+      });
 
-          $.ajax({
-            url: 'http://localhost:3000/api/prenotazioni',
-            method: 'POST',
-            contentType: 'application/json',
-            headers: { Authorization: `Bearer ${token}` },
-            data: JSON.stringify({
-              spazio_id,
-              data,
-              orario_inizio,
-              orario_fine
-            }),
-            success: function (res) {
-              // DEBUG: Mostra la risposta ricevuta dal backend
-              console.log('Risposta prenotazione:', res);
-              const importo = parseFloat(res.importo ?? res.prenotazione?.importo);
-              const msgImporto = isNaN(importo) ? '' : ` Importo: €${importo.toFixed(2)}`;
-              $('#prenotazioneAlert').html(`<div class="alert alert-success">✅ Prenotazione per <strong>${nome_spazio}</strong> registrata!${msgImporto}</div>`);
-              $('#formRicerca')[0].reset();
-              $('#risultatiSpazi').empty();
-            },
-            error: function (xhr) {
-              // Mostra dettagli dell'errore per debug
-              console.error('Errore AJAX:', xhr.status, xhr.responseText);
-              $('#prenotazioneAlert').html(`<div class="alert alert-danger">❌ Errore: ${xhr.responseJSON?.message || xhr.responseText || 'Prenotazione fallita'}</div>`);
-            }
-          });
-        });
-      },
-      error: function () {
-        $('#prenotazioneAlert').html('<div class="alert alert-danger">Errore durante la ricerca.</div>');
-      }
-    });
+    } catch (err) {
+      $('#prenotazioneAlert').html('<div class="alert alert-danger">Errore durante la ricerca.</div>');
+      hideSpinner();
+    }
+  });
+
+  $('#confirmPrenota').click(async function () {
+    const info = $('#confirmModal').data('spazio');
+    if (!info) return;
+    const { id: spazio_id, nome: nome_spazio } = info;
+    const data = $('#data').val();
+    const orario_inizio = $('#orarioInizio').val();
+    const orario_fine = $('#orarioFine').val();
+    const modalEl = document.getElementById('confirmModal');
+    const modal = bootstrap.Modal.getInstance(modalEl);
+    modal.hide();
+    showSpinner();
+    try {
+      const res = await fetch('http://localhost:3000/api/prenotazioni', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ spazio_id, data, orario_inizio, orario_fine })
+      });
+      const result = await res.json();
+      if (!res.ok) throw result;
+      const importo = parseFloat(result.importo ?? result.prenotazione?.importo);
+      const msgImporto = isNaN(importo) ? '' : ` Importo: €${importo.toFixed(2)}`;
+      $('#prenotazioneAlert').html(`<div class="alert alert-success">Prenotazione per <strong>${nome_spazio}</strong> registrata!${msgImporto}</div>`);
+      $('#formRicerca')[0].reset();
+      $('#risultatiSpazi').empty();
+    } catch (err) {
+      $('#prenotazioneAlert').html(`<div class="alert alert-danger">Errore: ${err.message || err.responseJSON?.message || 'Prenotazione fallita'}</div>`);
+    } finally {
+      hideSpinner();
+    }
   });
 });

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -5,6 +5,7 @@
   <title>CoWorkSpace - Prenota uno Spazio</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
 </head>
 <body class="bg-light">
@@ -50,11 +51,31 @@
     <div id="risultatiSpazi" class="row gy-4 justify-content-center"></div>
   </main>
 
+  <div id="loadingSpinner" class="d-flex">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+
+  <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmModalLabel">Conferma prenotazione</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="confirmModalBody"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="button" class="btn btn-primary" id="confirmPrenota">Conferma</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/menu.js"></script>
   <script src="js/prenotazione.js"></script>
-</body>
-</html>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace confirm with Bootstrap modal and add loading spinner for booking flow
- modernize booking JS with fetch/async and richer cards with icons and images
- update styles for spinner overlay and improved call-to-action buttons

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8f26d9b48328a29b6496741962d4