### PR TITLE
feat: make booking API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Le pagine statiche sono nella cartella `frontend`.
   npx serve frontend
   ```
 
+### Configurazione dell'endpoint API
+
+Lo script `frontend/js/prenotazione.js` usa la variabile globale `API_BASE` per determinare l'URL delle API. Il valore predefinito è `/api`, ma può essere sovrascritto:
+
+- **Variabile d'ambiente:** imposta `API_BASE` prima di servire il frontend (es. `API_BASE=https://example.com/api npx serve frontend`) e fai in modo che il server esponga tale valore come `window.API_BASE`.
+- **Script inline:** definisci `window.API_BASE` prima di includere `prenotazione.js`:
+
+  ```html
+  <script>
+    window.API_BASE = 'https://example.com/api';
+  </script>
+  <script src="js/prenotazione.js"></script>
+  ```
+
 ---
 
 Consulta la [specifica API](docs/api-spec.md) e la [documentazione del database](database/README-db.md) per maggiori dettagli sul progetto.

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -1,3 +1,5 @@
+const API_BASE = window.API_BASE || '/api';
+
 $(document).ready(function () {
   const token = localStorage.getItem('token');
 
@@ -46,7 +48,7 @@ $(document).ready(function () {
     showSpinner();
 
     try {
-      const res = await fetch('http://localhost:3000/api/disponibilita', {
+      const res = await fetch(`${API_BASE}/disponibilita`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -123,7 +125,7 @@ $(document).ready(function () {
     modal.hide();
     showSpinner();
     try {
-      const res = await fetch('http://localhost:3000/api/prenotazioni', {
+      const res = await fetch(`${API_BASE}/prenotazioni`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- allow prenotazione.js to derive API base from `window.API_BASE`
- update booking requests to use configurable base URL
- document how to override `API_BASE` from env or inline script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fc522576883289f4120454459413f