### PR TITLE
fix: show loading spinner by default

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -437,7 +437,6 @@ button.btn-lg {
   width: 100%;
   height: 100%;
   background: rgba(255,255,255,0.7);
-  display: none;
   align-items: center;
   justify-content: center;
   z-index: 2000;


### PR DESCRIPTION
## Summary
- remove `display: none` from `#loadingSpinner` so it can show when needed

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688fc5b1375083288c403018f514ddcf