### PR TITLE
Use Bootstrap classes to toggle loading spinner visibility

### DIFF
--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -15,11 +15,11 @@ $(document).ready(function () {
   });
 
   function showSpinner() {
-    $('#loadingSpinner').show();
+    $('#loadingSpinner').removeClass('d-none');
   }
 
   function hideSpinner() {
-    $('#loadingSpinner').hide();
+    $('#loadingSpinner').addClass('d-none');
   }
 
   // Cerca disponibilità spazi

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -51,7 +51,7 @@
     <div id="risultatiSpazi" class="row gy-4 justify-content-center"></div>
   </main>
 
-  <div id="loadingSpinner" class="d-flex">
+  <div id="loadingSpinner" class="d-flex d-none">
     <div class="spinner-border text-primary" role="status">
       <span class="visually-hidden">Loading...</span>
     </div>


### PR DESCRIPTION
## Summary
- default spinner hidden with Bootstrap's `d-none` class
- show/hide spinner by toggling `d-none` via jQuery

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fc5a37504832885e1f60bb91db4d3