### PR TITLE
Fix wrong spazi route path

### DIFF
--- a/backend/routes/spaziRoutes.js
+++ b/backend/routes/spaziRoutes.js
@@ -4,7 +4,7 @@ const spaziController = require('../controllers/spaziController');
 const { verificaToken } = require('../middleware/authMiddleware');
 
 // Recupera spazi per sede (accessibile a tutti)
-router.get('/spazi/:sede_id', spaziController.getSpaziPerSede);
+router.get('/:sede_id', spaziController.getSpaziPerSede);
 
 // Aggiungi spazio (protetto, per gestore)
 router.post('/', verificaToken, spaziController.aggiungiSpazio);


### PR DESCRIPTION
## Summary
- adjust spazi route to use root-level sede_id parameter

## Testing
- `node server.js` *(fails: DB_USER is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688fc8fce71883288dbb229a34cb2a07