### PR TITLE
refactor: move pagamenti storico to controller and router

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -76,3 +76,34 @@ exports.effettuaPagamento = async (req, res) => {
     res.status(500).json({ message: 'Errore del server durante il pagamento' });
   }
 };
+
+// 2. Storico pagamenti
+exports.storicoPagamenti = async (req, res) => {
+  const utente_id = req.utente.id;
+
+  try {
+    const result = await pool.query(
+      `SELECT
+        p.created_at AS data_pagamento,
+        p.metodo_pagamento,
+        p.importo,
+        pr.data AS data_prenotazione,
+        pr.orario_inizio,
+        pr.orario_fine,
+        s.nome AS nome_spazio
+      FROM pagamenti p
+      JOIN prenotazioni pr ON p.prenotazione_id = pr.id
+      JOIN spazi s ON pr.spazio_id = s.id
+      WHERE pr.utente_id = $1
+      ORDER BY p.created_at DESC`,
+      [utente_id]
+    );
+
+    res.json({ pagamenti: result.rows });
+  } catch (err) {
+    console.error('Errore query:', err);
+    res
+      .status(500)
+      .json({ message: 'Errore nel recupero dello storico pagamenti' });
+  }
+};

--- a/backend/routes/pagamentiRoutes.js
+++ b/backend/routes/pagamentiRoutes.js
@@ -4,5 +4,6 @@ const pagamentiController = require('../controllers/pagamentiController');
 const { verificaToken } = require('../middleware/authMiddleware'); // 👈 IMPORT CORRETTA
 
 router.post('/pagamento', verificaToken, pagamentiController.effettuaPagamento); // 👈 OK
+router.get('/storico', verificaToken, pagamentiController.storicoPagamenti);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,6 @@ const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 const express = require('express');
 const cors = require('cors');
-const db = require('./db'); // Aggiunto import del database
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -16,54 +15,6 @@ app.get('/api/test', (req, res) => {
   res.json({ message: 'Server is running' });
 });
 
-// Add pagamenti/storico endpoint
-app.get('/api/pagamenti/storico', async (req, res) => {
-  console.log('Ricevuta richiesta storico pagamenti'); // Debug log
-  
-  try {
-    const token = req.headers.authorization?.split(' ')[1];
-    if (!token) {
-      console.log('Token mancante'); // Debug log
-      return res.status(401).json({ message: 'Token mancante' });
-    }
-
-    const sessionQuery = await db.query(
-      'SELECT utente_id FROM sessioni WHERE token = $1',
-      [token]
-    );
-
-    if (sessionQuery.rows.length === 0) {
-      console.log('Sessione non trovata'); // Debug log
-      return res.status(401).json({ message: 'Sessione non valida' });
-    }
-
-    const utente_id = sessionQuery.rows[0].utente_id;
-    console.log('Utente ID:', utente_id); // Debug log
-
-    const result = await db.query(`
-      SELECT 
-        p.created_at as data_pagamento,
-        p.metodo_pagamento,
-        p.importo,
-        pr.data as data_prenotazione,
-        pr.orario_inizio,
-        pr.orario_fine,
-        s.nome as nome_spazio
-      FROM pagamenti p
-      JOIN prenotazioni pr ON p.prenotazione_id = pr.id
-      JOIN spazi s ON pr.spazio_id = s.id
-      WHERE pr.utente_id = $1
-      ORDER BY p.created_at DESC
-    `, [utente_id]);
-
-    console.log('Pagamenti trovati:', result.rows.length); // Debug log
-    res.json({ pagamenti: result.rows });
-  } catch (err) {
-    console.error('Errore query:', err); // Debug log
-    res.status(500).json({ message: 'Errore nel recupero dello storico pagamenti' });
-  }
-});
-
 // Rotte
 app.get('/', (_, res) => res.sendFile(path.join(__dirname, '../frontend/index.html')));
 app.use('/api', require('./routes/authRoutes'));           // Login, registrazione, logout
@@ -71,7 +22,7 @@ app.use('/api', require('./routes/userRoutes'));           // Profilo utente
 app.use('/api/sedi', require('./routes/sediRoutes'));
 app.use('/api/spazi', require('./routes/spaziRoutes'));
 const prenotazioniRoutes = require('./routes/prenotazioni');
-const pagamentiRoutes = require('./routes/pagamenti');
+const pagamentiRoutes = require('./routes/pagamentiRoutes');
 
 app.use('/api/prenotazioni', prenotazioniRoutes);
 app.use('/api/pagamenti', pagamentiRoutes);


### PR DESCRIPTION
## Summary
- add `storicoPagamenti` controller to fetch user payments
- expose `/api/pagamenti/storico` via `pagamentiRoutes`
- drop duplicate history endpoint from server and use router only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689243d57634832895cc3688b7dc1c02