### PR TITLE
chore: fix payment endpoint path

### DIFF
--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -193,7 +193,7 @@ $(document).ready(function () {
     const metodo = $('#metodo').val();
 
     $.ajax({
-      url: 'http://localhost:3000/api/pagamento',
+        url: 'http://localhost:3000/api/pagamenti/pagamento',
       method: 'POST',
       contentType: 'application/json',
 


### PR DESCRIPTION
## Summary
- point payment submission to `/api/pagamenti/pagamento`
- confirm other payment AJAX calls already use `/api/pagamenti`

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_689243e289c08328872b45e69516bd69