### PR TITLE
Rinomina colonne pagamenti a timestamp e metodo

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -80,8 +80,8 @@ exports.storicoPagamenti = async (req, res) => {
   try {
     const result = await pool.query(
       `SELECT
-        p.timestamp AS data_pagamento,
-        p.metodo AS metodo_pagamento,
+        p.timestamp,
+        p.metodo,
         p.importo,
         pr.data AS data_prenotazione,
         pr.orario_inizio,

--- a/backend/db/migrations/[timestamp]_create_pagamenti_table.sql
+++ b/backend/db/migrations/[timestamp]_create_pagamenti_table.sql
@@ -1,8 +1,7 @@
 CREATE TABLE IF NOT EXISTS pagamenti (
   id SERIAL PRIMARY KEY,
   prenotazione_id INTEGER REFERENCES prenotazioni(id),
-  data_pagamento TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  metodo_pagamento VARCHAR(50) NOT NULL,
-  importo DECIMAL(10,2) NOT NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  metodo VARCHAR(50) NOT NULL,
+  importo DECIMAL(10,2) NOT NULL
 );

--- a/backend/db/migrations/create_pagamenti.sql
+++ b/backend/db/migrations/create_pagamenti.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS pagamenti (
     id SERIAL PRIMARY KEY,
     prenotazione_id INTEGER REFERENCES prenotazioni(id),
-    metodo_pagamento VARCHAR(50) NOT NULL,
-    importo DECIMAL(10,2) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    metodo VARCHAR(50) NOT NULL,
+    importo DECIMAL(10,2) NOT NULL
 );

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -143,7 +143,7 @@ $(document).ready(function () {
         }
 
         pagamenti.forEach(p => {
-          const data = new Date(p.data_pagamento).toLocaleString('it-IT', {
+          const data = new Date(p.timestamp).toLocaleString('it-IT', {
             day: '2-digit',
             month: '2-digit',
             year: 'numeric',
@@ -159,7 +159,7 @@ $(document).ready(function () {
               <td>${p.nome_spazio}</td>
               <td>${dataPrenotazione} ${p.orario_inizio.slice(0,5)}-${p.orario_fine.slice(0,5)}</td>
               <td>€${parseFloat(p.importo).toFixed(2)}</td>
-              <td>${p.metodo_pagamento}</td>
+              <td>${p.metodo}</td>
             </tr>
           `);
         });


### PR DESCRIPTION
## Summary
- replace `data_pagamento`/`metodo_pagamento` with `timestamp`/`metodo` in pagamenti migrations
- adjust controller and frontend to use renamed columns

## Testing
- `psql -h localhost -U postgres -d coworkspace -c "ALTER TABLE pagamenti RENAME COLUMN data_pagamento TO \"timestamp\"; ALTER TABLE pagamenti RENAME COLUMN metodo_pagamento TO metodo; ALTER TABLE pagamenti DROP COLUMN created_at;"`
- `node - <<'NODE' ... effettuaPagamento ... NODE`
- `node - <<'NODE' ... storicoPagamenti ... NODE`
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6892491637f483288798fd173c31bf4d