### PR TITLE
feat: add nome column to spazi

### DIFF
--- a/backend/db/migrations/202312040000_add_nome_descrizione_to_spazi.sql
+++ b/backend/db/migrations/202312040000_add_nome_descrizione_to_spazi.sql
@@ -1,0 +1,15 @@
+-- Migration: add nome and descrizione columns to spazi
+ALTER TABLE IF EXISTS spazi
+    ADD COLUMN IF NOT EXISTS nome VARCHAR(100) NOT NULL DEFAULT 'Spazio';
+
+ALTER TABLE IF EXISTS spazi
+    ADD COLUMN IF NOT EXISTS descrizione TEXT;
+
+-- Populate existing rows with placeholder names
+UPDATE spazi
+   SET nome = 'Spazio ' || id
+ WHERE nome = 'Spazio';
+
+-- Remove default to require explicit nome on future inserts
+ALTER TABLE spazi
+    ALTER COLUMN nome DROP DEFAULT;

--- a/database/README-db.md
+++ b/database/README-db.md
@@ -57,6 +57,8 @@ Definisce un'unità prenotabile all'interno di una sede (es. sala, scrivania, uf
 |---------------|--------------|------------------------------------------|
 | `id`          | SERIAL       | Identificativo dello spazio              |
 | `sede_id`     | INTEGER      | FK → `Sede(id)`                          |
+| `nome`        | VARCHAR(100) | Nome dello spazio                        |
+| `descrizione` | TEXT         | Descrizione dello spazio                 |
 | `tipo_spazio` | VARCHAR(20)  | Tipo: `scrivania`, `ufficio`, `sala`     |
 | `servizi`     | TEXT         | Servizi inclusi (es. WiFi, stampante)    |
 | `prezzo_orario`  | NUMERIC(6,2) | Prezzo orario dello spazio               |

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -20,6 +20,8 @@ CREATE TABLE sedi (
 CREATE TABLE spazi (
   id SERIAL PRIMARY KEY,
   sede_id INTEGER NOT NULL REFERENCES sedi(id) ON DELETE CASCADE,
+  nome VARCHAR(100) NOT NULL,
+  descrizione TEXT,
   tipo_spazio VARCHAR(20) CHECK (tipo_spazio IN ('scrivania', 'ufficio', 'sala')) NOT NULL,
   servizi TEXT,
   prezzo_orario NUMERIC(6,2) NOT NULL


### PR DESCRIPTION
## Summary
- add `nome` and optional `descrizione` to `spazi` schema
- document new `spazi` columns
- provide migration to add columns and backfill existing records

## Testing
- `psql -d postgres -f backend/db/migrations/202312040000_add_nome_descrizione_to_spazi.sql` *(fails: connection refused)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68925f3fb1308328ade84da005b53880