### PR TITLE
Fix duplicate closing tags in admin page

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -46,5 +46,3 @@
   <script src="js/admin.js"></script>
 </body>
 </html>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- remove duplicate closing `</body>` and `</html>` tags from admin page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/CoWorkSpace/package.json')*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892640017408328b8aaadd39653c01f