### PR TITLE
Gestisci visibilità navbar via classe show

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
 <body>
 
   <!-- Navbar nascosta di default, mostrata solo dopo login -->
-  <nav id="mainNavbar" class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3" style="display:none;">
+  <nav id="mainNavbar" class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
     <div class="container">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" 

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -103,12 +103,12 @@ $(function () {
     const utente = JSON.parse(localStorage.getItem('utente'));
     if (utente && utente.nome) {
       $('#authButtons').hide();
-      $('#mainNavbar').show();
+      $('#mainNavbar').addClass('show');
       $('#nomeUtente').text(utente.nome);
       $('#ruoloUtente').text(utente.ruolo ? `(${utente.ruolo})` : '');
     } else {
       $('#authButtons').show();
-      $('#mainNavbar').hide();
+      $('#mainNavbar').removeClass('show');
       $('#nomeUtente').text('');
       $('#ruoloUtente').text('');
     }


### PR DESCRIPTION
## Summary
- Remove inline display style from main navbar on index page
- Use CSS `show` class in auth logic to toggle navbar visibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926407d290832898cc57079d29d9fa