### PR TITLE
Limit payment history results

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -76,6 +76,7 @@ exports.effettuaPagamento = async (req, res) => {
 // 2. Storico pagamenti
 exports.storicoPagamenti = async (req, res) => {
   const utente_id = req.utente.id;
+  const limite = parseInt(req.query.limit, 10) || 5;
 
   try {
     const result = await pool.query(
@@ -91,8 +92,9 @@ exports.storicoPagamenti = async (req, res) => {
       JOIN prenotazioni pr ON p.prenotazione_id = pr.id
       JOIN spazi s ON pr.spazio_id = s.id
       WHERE pr.utente_id = $1
-      ORDER BY p.timestamp DESC`,
-      [utente_id]
+      ORDER BY p.timestamp DESC
+      LIMIT $2`,
+      [utente_id, limite]
     );
 
     res.json({ pagamenti: result.rows });

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -80,10 +80,13 @@ Filtri disponibili su `/api/sedi`:
 
 ## 💳 Pagamenti
 
-| Metodo | Endpoint            | Descrizione                            |
-|--------|---------------------|----------------------------------------|
-| POST   | `/api/pagamento`    | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) – l'importo è letto dalla prenotazione |
+| Metodo | Endpoint                 | Descrizione                                                         |
+|--------|--------------------------|---------------------------------------------------------------------|
+| POST   | `/api/pagamento`         | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) – l'importo è letto dalla prenotazione |
+| GET    | `/api/pagamenti/storico` | Restituisce lo storico pagamenti dell'utente (parametro opzionale `limit`, default 5) |
 
+**Query params GET `/api/pagamenti/storico`:**
+- `limit` (opzionale): numero massimo di pagamenti restituiti (default 5)
 
 ---
 

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -129,7 +129,7 @@ $(document).ready(function () {
   // Funzione per caricare e visualizzare lo storico pagamenti
   function caricaStoricoPagamenti() {
     $.ajax({
-      url: 'http://localhost:3000/api/pagamenti/storico',
+      url: 'http://localhost:3000/api/pagamenti/storico?limit=5',
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
       success: function(res) {

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -67,6 +67,7 @@
     <!-- Nuova sezione storico pagamenti -->
     <div class="container py-4">
       <h2>Storico Pagamenti</h2>
+      <p class="text-muted small">Sono mostrati solo gli ultimi cinque pagamenti.</p>
       <div class="table-responsive">
         <table class="table table-striped">
           <thead>


### PR DESCRIPTION
## Summary
- allow `storicoPagamenti` to accept an optional `limit` query param and enforce it in SQL
- fetch only the latest five payments on the frontend and note this in the UI
- document `limit` parameter for the payment history endpoint

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689268c788348328b2d050c65aba1017