### PR TITLE
Use style.css for page backgrounds

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -7,7 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
 </head>
-<body class="bg-light">
+<body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
     <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>

--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -7,7 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
 </head>
-<body class="bg-light">
+<body>
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
     <div class="container d-flex align-items-center">

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -7,7 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
 </head>
-  <body class="bg-light">
+  <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
       <div class="container d-flex align-items-center">
         <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -8,7 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
 </head>
-<body class="bg-light">
+<body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm py-3">
     <div class="container d-flex align-items-center">
       <a class="navbar-brand fw-bold" href="index.html">CoWorkSpace</a>


### PR DESCRIPTION
## Summary
- Remove Bootstrap `bg-light` class from page bodies to let style.css drive page backgrounds
- All pages now inherit background styles from `frontend/css/style.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926c9cbcf48328ac99bbe405c7d737