### PR TITLE
chore: unify frontend spacing with py-5

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -26,7 +26,7 @@
     </div>
   </nav>
 
-  <div class="container py-5">
+  <main class="container py-5">
     <h1 class="mb-4">👩‍💼 Pannello Amministratore - <span id="adminNome"></span></h1>
 
     <section>
@@ -38,7 +38,7 @@
       <h3>Sedi</h3>
       <ul id="listaSedi" class="list-group mb-4"></ul>
     </section>
-  </div>
+  </main>
 
   <footer class="footer text-center py-3 bg-light text-muted mt-auto">
     &copy; 2025 CoWorkSpace. Tutti i diritti riservati.

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -34,7 +34,7 @@ body {
 
 main.container {
   flex-grow: 1;
-  padding: 3rem 1rem;
+  padding: 0 1rem;
   max-width: 960px;
   margin: 0 auto;
 }
@@ -236,8 +236,6 @@ h1.main-title {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 4rem;
-  padding-bottom: 4rem;
 }
 
 /* Form più largo, centrato con box */

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -36,7 +36,7 @@
     </div>
   </header>
 
-  <main class="container my-5">
+  <main class="container py-5">
     <section>
       <h2 class="mb-4">Le tue prenotazioni</h2>
       <div id="dashboardAlert"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
     </div>
   </nav>
 
-  <main class="container mt-5">
+  <main class="container py-5">
 
     <h1 class="main-title text-center mb-5">Benvenuto in CoWorkSpace</h1>
 

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -26,7 +26,7 @@
       </div>
     </nav>
 
-    <div class="container py-5">
+    <main class="container py-5">
       <h1>Pagamento</h1>
 
       <!-- Card riepilogo -->
@@ -62,10 +62,10 @@
       </form>
 
       <div id="alertPagamento"></div>
-    </div>
+    </main>
 
     <!-- Nuova sezione storico pagamenti -->
-    <div class="container py-4">
+    <div class="container py-5">
       <h2>Storico Pagamenti</h2>
       <p class="text-muted small">Sono mostrati solo gli ultimi cinque pagamenti.</p>
       <div class="table-responsive">

--- a/frontend/prenotazione.html
+++ b/frontend/prenotazione.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
 
-  <main class="container prenotazione-main">
+  <main class="container prenotazione-main py-5">
     <div id="authAlert"></div>
     <h1 class="main-title">Prenota uno spazio</h1>
 

--- a/frontend/profilo.html
+++ b/frontend/profilo.html
@@ -24,7 +24,7 @@
     </div>
   </nav>
 
-  <main class="container my-5" style="max-width: 500px;">
+  <main class="container py-5" style="max-width: 500px;">
     <h2 class="mb-4">Aggiorna Profilo</h2>
     <div id="profiloAlert"></div>
     <form id="profiloForm">


### PR DESCRIPTION
## Summary
- replace payment page wrapper with `<main>` and match historical section spacing
- standardize main containers across frontend pages to use Bootstrap's `py-5`
- rely on `py-5` for vertical spacing in CSS, removing custom paddings

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926c9f85088328b78b28f46e314b83