### PR TITLE
feat: add sede options endpoint and datalist

### DIFF
--- a/backend/controllers/sediController.js
+++ b/backend/controllers/sediController.js
@@ -40,6 +40,33 @@ exports.getSedi = async (req, res) => {
   }
 };
 
+// Restituisce liste di valori per filtri pubblici
+exports.getOpzioni = async (req, res) => {
+  try {
+    const cittaResult = await pool.query('SELECT DISTINCT citta FROM sedi');
+    const tipoResult = await pool.query('SELECT DISTINCT tipo_spazio FROM spazi');
+    const serviziResult = await pool.query('SELECT servizi FROM spazi WHERE servizi IS NOT NULL');
+
+    const serviziSet = new Set();
+    serviziResult.rows.forEach(row => {
+      row.servizi
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .forEach(s => serviziSet.add(s));
+    });
+
+    res.json({
+      citta: cittaResult.rows.map(r => r.citta),
+      tipi: tipoResult.rows.map(r => r.tipo_spazio),
+      servizi: Array.from(serviziSet),
+    });
+  } catch (err) {
+    console.error('Errore nel recupero opzioni sedi:', err);
+    res.status(500).json({ message: 'Errore del server' });
+  }
+};
+
 // Recupera sedi di un gestore
 exports.getSediGestore = async (req, res) => {
   const { id } = req.params;

--- a/backend/routes/sediRoutes.js
+++ b/backend/routes/sediRoutes.js
@@ -9,6 +9,9 @@ router.post('/', verificaToken, sediController.aggiungiSede);
 // Recupera sedi per gestore (protetto)
 router.get('/gestore/:id', verificaToken, sediController.getSediGestore);
 
+// Recupera liste di opzioni pubbliche
+router.get('/opzioni', sediController.getOpzioni);
+
 // Dettaglio di una singola sede
 router.get('/:id', sediController.getSedeById);
 

--- a/frontend/js/sedi.js
+++ b/frontend/js/sedi.js
@@ -1,4 +1,17 @@
 $(document).ready(function () {
+  function caricaOpzioni() {
+    $.getJSON('http://localhost:3000/api/sedi/opzioni', function (data) {
+      const cittaList = $('#cittaOptions').empty();
+      (data.citta || []).forEach(c => cittaList.append(`<option value="${c}"></option>`));
+
+      const tipoList = $('#tipoOptions').empty();
+      (data.tipi || []).forEach(t => tipoList.append(`<option value="${t}"></option>`));
+
+      const serviziList = $('#serviziOptions').empty();
+      (data.servizi || []).forEach(s => serviziList.append(`<option value="${s}"></option>`));
+    });
+  }
+
   function caricaSedi() {
     const citta = $('#filtroCitta').val();
     const tipo = $('#filtroTipo').val();
@@ -77,5 +90,6 @@ $(document).ready(function () {
     });
   });
 
+  caricaOpzioni();
   caricaSedi();
 });

--- a/frontend/sedi.html
+++ b/frontend/sedi.html
@@ -31,13 +31,16 @@
 
     <form id="formFiltri" class="row g-3 mb-4">
       <div class="col-md-4">
-        <input type="text" id="filtroCitta" class="form-control" placeholder="Città" />
+        <input type="text" id="filtroCitta" list="cittaOptions" class="form-control" placeholder="Città" />
+        <datalist id="cittaOptions"></datalist>
       </div>
       <div class="col-md-4">
-        <input type="text" id="filtroTipo" class="form-control" placeholder="Tipo spazio" />
+        <input type="text" id="filtroTipo" list="tipoOptions" class="form-control" placeholder="Tipo spazio" />
+        <datalist id="tipoOptions"></datalist>
       </div>
       <div class="col-md-4">
-        <input type="text" id="filtroServizio" class="form-control" placeholder="Servizio" />
+        <input type="text" id="filtroServizio" list="serviziOptions" class="form-control" placeholder="Servizio" />
+        <datalist id="serviziOptions"></datalist>
       </div>
       <div class="col-12">
         <button type="submit" class="btn btn-primary">Filtra</button>


### PR DESCRIPTION
## Summary
- add public endpoint to fetch available sedi filter options
- parse database for distinct cities, space types and services
- populate new filter datalists on the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68927177796483289740db71d8234fca