### PR TITLE
feat: allow filtering by space type

### DIFF
--- a/backend/controllers/sediController.js
+++ b/backend/controllers/sediController.js
@@ -3,13 +3,13 @@ const pool = require('../db');
 // Recupera sedi con filtri opzionali per città, tipo spazio e servizi
 exports.getSedi = async (req, res) => {
   try {
-    const { citta, servizio } = req.query;
+    const { citta, servizio, tipo } = req.query;
 
     let query = 'SELECT DISTINCT s.* FROM sedi s';
     const where = [];
     const params = [];
 
-    if (servizio) {
+    if (servizio || tipo) {
       query += ' JOIN spazi sp ON s.id = sp.sede_id';
     }
 
@@ -22,6 +22,11 @@ exports.getSedi = async (req, res) => {
       // Try common column names for services
       params.push(`%${servizio}%`);
       where.push(`(sp.servizi ILIKE $${params.length} OR sp.servizi_offerti ILIKE $${params.length} OR sp.services ILIKE $${params.length})`);
+    }
+
+    if (tipo) {
+      params.push(tipo);
+      where.push(`sp.tipo_spazio = $${params.length}`);
     }
 
     if (where.length > 0) {


### PR DESCRIPTION
## Summary
- allow filtering locations by `tipo` query parameter

## Testing
- `npm test` (fails: Error: no test specified)
- `node server.js` (fails: DB_USER is missing)
- `curl -sS http://localhost:3000/api/sedi?tipo=Sala%20Riunioni` (fails: couldn't connect to server)


------
https://chatgpt.com/codex/tasks/task_e_689454cc4b3883288a94160de8c463f0