### PR TITLE
Add services field to spazio creation

### DIFF
--- a/backend/controllers/gestoreController.js
+++ b/backend/controllers/gestoreController.js
@@ -18,12 +18,24 @@ exports.getSediGestite = async (req, res) => {
 
 // 2. Aggiungi spazio in una sede
 exports.aggiungiSpazio = async (req, res) => {
-  const { sede_id, nome, descrizione, prezzo_orario, capienza } = req.body;
+  const { sede_id, nome, descrizione, prezzo_orario, capienza, servizi } = req.body;
+
+  if (!sede_id || !nome || prezzo_orario === undefined || capienza === undefined || !servizi) {
+    return res.status(400).json({ message: 'Tutti i campi sono obbligatori.' });
+  }
+
+  if (isNaN(prezzo_orario) || prezzo_orario < 0) {
+    return res.status(400).json({ message: 'Prezzo orario non valido.' });
+  }
+
+  if (isNaN(capienza) || capienza <= 0) {
+    return res.status(400).json({ message: 'Capienza non valida.' });
+  }
 
   try {
     const result = await pool.query(
-      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [sede_id, nome, descrizione, prezzo_orario, capienza]
+      'INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza, servizi) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+      [sede_id, nome, descrizione, prezzo_orario, capienza, servizi]
     );
     res.status(201).json({ spazio: result.rows[0] });
   } catch (err) {

--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -79,6 +79,10 @@
                 <label for="descrizioneSpazio" class="form-label">Descrizione</label>
                 <textarea id="descrizioneSpazio" class="form-control form-lg" rows="3" placeholder="Descrivi lo spazio..." required></textarea>
               </div>
+              <div class="mb-3">
+                <label for="serviziSpazio" class="form-label">Servizi</label>
+                <textarea id="serviziSpazio" class="form-control form-lg" rows="2" placeholder="Es: WiFi, Proiettore, Lavagna" required></textarea>
+              </div>
               <div class="row">
                 <div class="col-md-6 mb-3">
                   <label for="prezzoOrario" class="form-label">Prezzo Orario (€)</label>

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -150,6 +150,7 @@ $(document).ready(function () {
     const sede_id = $('#selezionaSede').val();
     const nome = $('#nomeSpazio').val();
     const descrizione = $('#descrizioneSpazio').val();
+    const servizi = $('#serviziSpazio').val();
     const prezzo_orario = parseFloat($('#prezzoOrario').val());
     const capienza = parseInt($('#capienza').val());
 
@@ -168,12 +169,17 @@ $(document).ready(function () {
       return;
     }
 
+    if (!servizi || !servizi.trim()) {
+      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Inserisci i servizi offerti nello spazio.</div>`);
+      return;
+    }
+
     $.ajax({
       url: 'http://localhost:3000/api/spazi',
       method: 'POST',
       contentType: 'application/json',
       headers: { Authorization: `Bearer ${token}` },
-      data: JSON.stringify({ sede_id, nome, descrizione, prezzo_orario, capienza }),
+      data: JSON.stringify({ sede_id, nome, descrizione, servizi, prezzo_orario, capienza }),
       success: function () {
         $('#alertGestore').html(`<div class="alert alert-success">✅ Spazio aggiunto con successo!</div>`);
         $('#formSpazio')[0].reset();


### PR DESCRIPTION
## Summary
- add "servizi" textarea to gestore space form
- send and validate services in frontend and backend
- handle services column when inserting new space

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894612f8a448328865c33d10f47d2a4