### PR TITLE
Add space type selection and backend validation

### DIFF
--- a/backend/controllers/spaziController.js
+++ b/backend/controllers/spaziController.js
@@ -29,6 +29,11 @@ exports.aggiungiSpazio = async (req, res) => {
     servizi,
   } = req.body;
 
+  const tipiValidi = ['scrivania', 'ufficio', 'sala'];
+  if (!tipo_spazio || !tipiValidi.includes(tipo_spazio)) {
+    return res.status(400).json({ message: 'Tipo di spazio non valido' });
+  }
+
   try {
     const result = await pool.query(
       `INSERT INTO spazi (sede_id, nome, descrizione, prezzo_orario, capienza, tipo_spazio, servizi)

--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -76,6 +76,15 @@
                 <input type="text" id="nomeSpazio" class="form-control form-lg" placeholder="Es: Sala Riunioni Grande" required />
               </div>
               <div class="mb-3">
+                <label for="tipoSpazio" class="form-label">Tipo di Spazio</label>
+                <select id="tipoSpazio" class="form-select form-lg" required>
+                  <option value="">-- Seleziona il tipo --</option>
+                  <option value="scrivania">Scrivania</option>
+                  <option value="ufficio">Ufficio</option>
+                  <option value="sala">Sala</option>
+                </select>
+              </div>
+              <div class="mb-3">
                 <label for="descrizioneSpazio" class="form-label">Descrizione</label>
                 <textarea id="descrizioneSpazio" class="form-control form-lg" rows="3" placeholder="Descrivi lo spazio..." required></textarea>
               </div>

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -149,6 +149,7 @@ $(document).ready(function () {
 
     const sede_id = $('#selezionaSede').val();
     const nome = $('#nomeSpazio').val();
+    const tipo_spazio = $('#tipoSpazio').val();
     const descrizione = $('#descrizioneSpazio').val();
     const servizi = $('#serviziSpazio').val();
     const prezzo_orario = parseFloat($('#prezzoOrario').val());
@@ -169,6 +170,11 @@ $(document).ready(function () {
       return;
     }
 
+    if (!tipo_spazio) {
+      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Seleziona il tipo di spazio.</div>`);
+      return;
+    }
+
     if (!servizi || !servizi.trim()) {
       $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Inserisci i servizi offerti nello spazio.</div>`);
       return;
@@ -179,7 +185,7 @@ $(document).ready(function () {
       method: 'POST',
       contentType: 'application/json',
       headers: { Authorization: `Bearer ${token}` },
-      data: JSON.stringify({ sede_id, nome, descrizione, servizi, prezzo_orario, capienza }),
+      data: JSON.stringify({ sede_id, nome, tipo_spazio, descrizione, servizi, prezzo_orario, capienza }),
       success: function () {
         $('#alertGestore').html(`<div class="alert alert-success">✅ Spazio aggiunto con successo!</div>`);
         $('#formSpazio')[0].reset();


### PR DESCRIPTION
## Summary
- add `tipo_spazio` select in the manager's new-space form
- include `tipo_spazio` in client submission and validate before sending
- validate `tipo_spazio` on the server and store it when creating a space

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689463d4060883289be24509cbe59eb3