### PR TITLE
Gestore: refine space type selection handling

### DIFF
--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -78,7 +78,7 @@
               <div class="mb-3">
                 <label for="tipoSpazio" class="form-label">Tipo di Spazio</label>
                 <select id="tipoSpazio" class="form-select form-lg" required>
-                  <option value="">-- Seleziona il tipo --</option>
+                  <option value="">-- Seleziona il tipo di spazio --</option>
                   <option value="scrivania">Scrivania</option>
                   <option value="ufficio">Ufficio</option>
                   <option value="sala">Sala</option>

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -171,7 +171,7 @@ $(document).ready(function () {
     }
 
     if (!tipo_spazio) {
-      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Seleziona il tipo di spazio.</div>`);
+      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Seleziona il tipo di spazio (scrivania, ufficio o sala).</div>`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Clarify space type dropdown placeholder in gestore form
- Expand validation message to list allowed space types

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68946941fcd8832891f5390002821351