### PR TITLE
Allow selecting multiple services for spaces

### DIFF
--- a/frontend/gestore.html
+++ b/frontend/gestore.html
@@ -90,7 +90,12 @@
               </div>
               <div class="mb-3">
                 <label for="serviziSpazio" class="form-label">Servizi</label>
-                <textarea id="serviziSpazio" class="form-control form-lg" rows="2" placeholder="Es: WiFi, Proiettore, Lavagna" required></textarea>
+                <select id="serviziSpazio" class="form-select form-lg" multiple required>
+                  <option value="WiFi">WiFi</option>
+                  <option value="Proiettore">Proiettore</option>
+                  <option value="Lavagna">Lavagna</option>
+                  <option value="Stampante">Stampante</option>
+                </select>
               </div>
               <div class="row">
                 <div class="col-md-6 mb-3">

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -175,8 +175,8 @@ $(document).ready(function () {
       return;
     }
 
-    if (!servizi || !servizi.trim()) {
-      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Inserisci i servizi offerti nello spazio.</div>`);
+    if (!servizi || servizi.length === 0) {
+      $('#alertGestore').html(`<div class="alert alert-warning">⚠️ Seleziona almeno un servizio.</div>`);
       return;
     }
 
@@ -185,7 +185,7 @@ $(document).ready(function () {
       method: 'POST',
       contentType: 'application/json',
       headers: { Authorization: `Bearer ${token}` },
-      data: JSON.stringify({ sede_id, nome, tipo_spazio, descrizione, servizi, prezzo_orario, capienza }),
+      data: JSON.stringify({ sede_id, nome, tipo_spazio, descrizione, servizi: servizi.join(','), prezzo_orario, capienza }),
       success: function () {
         $('#alertGestore').html(`<div class="alert alert-success">✅ Spazio aggiunto con successo!</div>`);
         $('#formSpazio')[0].reset();


### PR DESCRIPTION
## Summary
- replace services textarea with multi-select of allowed options
- read selected services as array, validate one or more, and send comma-separated string to API

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68946ba4750c8328a36fcd458510e43a