### PR TITLE
Fix riepilogo route precedence

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,10 +26,10 @@ const pagamentiRoutes = require('./routes/pagamentiRoutes');
 
 app.use('/api/prenotazioni', prenotazioniRoutes);
 app.use('/api/pagamenti', pagamentiRoutes);
+app.use('/api/riepilogo', require('./routes/riepilogoRoutes'));
 app.use('/api', require('./routes/gestoreRoutes'));        // Dashboard gestore
 app.use('/api/admin', require('./routes/adminRoutes'));    // Area admin
 app.use('/api', require('./routes/disponibilitaRoutes'));
-app.use('/api/riepilogo', require('./routes/riepilogoRoutes'));
 
 
 // Avvio server


### PR DESCRIPTION
## Summary
- ensure /api/riepilogo is registered before gestore routes to avoid collisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68946ebc73588328b12728ef6503e28a