### PR TITLE
Refactor booking summary routing

### DIFF
--- a/backend/controllers/gestoreController.js
+++ b/backend/controllers/gestoreController.js
@@ -143,26 +143,3 @@ exports.visualizzaPrenotazioniRicevute = async (req, res) => {
     res.status(500).json({ message: 'Errore del server' });
   }
 };
-
-// 7. Riepilogo prenotazioni per gestore (NUOVA funzione)
-exports.getRiepilogoPrenotazioni = async (req, res) => {
-  const { gestore_id } = req.params;
-
-  try {
-    const result = await pool.query(
-      `SELECT COUNT(*) AS totale_prenotazioni,
-              MIN(p.data) AS prima_prenotazione,
-              MAX(p.data) AS ultima_prenotazione
-       FROM prenotazioni p
-       JOIN spazi s ON p.spazio_id = s.id
-       JOIN sedi sede ON s.sede_id = sede.id
-       WHERE sede.gestore_id = $1`,
-      [gestore_id]
-    );
-
-    res.json({ riepilogo: result.rows[0] });
-  } catch (err) {
-    console.error('Errore nel riepilogo prenotazioni:', err);
-    res.status(500).json({ message: 'Errore del server' });
-  }
-};

--- a/backend/routes/gestoreRoutes.js
+++ b/backend/routes/gestoreRoutes.js
@@ -9,6 +9,4 @@ router.put('/spazi/:id', verificaToken, gestoreController.modificaSpazio);
 router.delete('/spazi/:id', verificaToken, gestoreController.eliminaSpazio);
 router.post('/spazi/:id/disponibilita', verificaToken, gestoreController.aggiungiDisponibilita);
 router.get('/prenotazioni/:gestore_id', verificaToken, gestoreController.visualizzaPrenotazioniRicevute);
-router.get('/riepilogo/:gestore_id', verificaToken, gestoreController.getRiepilogoPrenotazioni);
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- Remove duplicate booking summary handler from gestore controller and routes
- Ensure booking summaries served solely by riepilogo controller

## Testing
- `npm test` (fails: `Error: no test specified`)


------
https://chatgpt.com/codex/tasks/task_e_68947414aed88328892d407fc0559bcf