### PR TITLE
Cleanup duplicate riepilogo route

### DIFF
--- a/backend/routes/gestoreRoutes.js
+++ b/backend/routes/gestoreRoutes.js
@@ -9,5 +9,4 @@ router.put('/spazi/:id', verificaToken, verificaGestore, gestoreController.modif
 router.delete('/spazi/:id', verificaToken, verificaGestore, gestoreController.eliminaSpazio);
 router.post('/spazi/:id/disponibilita', verificaToken, verificaGestore, gestoreController.aggiungiDisponibilita);
 router.get('/prenotazioni/:gestore_id', verificaToken, verificaGestore, gestoreController.visualizzaPrenotazioniRicevute);
-router.get('/riepilogo/:gestore_id', verificaToken, verificaGestore, gestoreController.getRiepilogoPrenotazioni);
 module.exports = router;


### PR DESCRIPTION
## Summary
- remove legacy `/riepilogo/:gestore_id` route from `gestoreRoutes`
- verify frontend points to `/api/riepilogo/:id` handled by `riepilogoRoutes`

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689478839bc48328990deb973a86bf1e