### PR TITLE
Restrict gestore to own sedi

### DIFF
--- a/backend/controllers/sediController.js
+++ b/backend/controllers/sediController.js
@@ -108,10 +108,14 @@ exports.getOpzioni = async (req, res) => {
 // Recupera sedi di un gestore
 exports.getSediGestore = async (req, res) => {
   const { id } = req.params;
+  const requestedId = parseInt(id, 10);
+  if (req.utente.id !== requestedId) {
+    return res.status(403).json({ message: 'Accesso negato' });
+  }
   try {
     const result = await pool.query(
       'SELECT id, nome, citta FROM sedi WHERE gestore_id = $1',
-      [id]
+      [requestedId]
     );
     res.json(result.rows);
   } catch (err) {

--- a/backend/routes/sediRoutes.js
+++ b/backend/routes/sediRoutes.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const sediController = require('../controllers/sediController');
-const { verificaToken } = require('../middleware/authMiddleware');
+const { verificaToken, verificaGestore } = require('../middleware/authMiddleware');
 
 // Aggiungi sede (protetto)
 router.post('/', verificaToken, sediController.aggiungiSede);
 
 // Recupera sedi per gestore (protetto)
-router.get('/gestore/:id', verificaToken, sediController.getSediGestore);
+router.get('/gestore/:id', verificaToken, verificaGestore, sediController.getSediGestore);
 
 // Recupera liste di opzioni pubbliche
 router.get('/opzioni', sediController.getOpzioni);


### PR DESCRIPTION
## Summary
- enforce gestore role on `/gestore/:id` route
- ensure gestore can only fetch their own `sedi`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68947ba326f88328b91867b405094c68