### PR TITLE
Protect riepilogo endpoint with gestore checks

### DIFF
--- a/backend/controllers/riepilogoController.js
+++ b/backend/controllers/riepilogoController.js
@@ -1,7 +1,11 @@
 const pool = require('../db');
 
 exports.getRiepilogoPrenotazioni = async (req, res) => {
-  const gestoreId = req.params.id;
+  const gestoreId = parseInt(req.params.id, 10);
+
+  if (req.utente.id !== gestoreId) {
+    return res.status(403).json({ message: 'Accesso negato' });
+  }
 
   try {
     // Query che aggrega il numero di prenotazioni per ogni spazio gestito dal gestore

--- a/backend/routes/riepilogoRoutes.js
+++ b/backend/routes/riepilogoRoutes.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const riepilogoController = require('../controllers/riepilogoController');
-const { verificaToken } = require('../middleware/authMiddleware');
+const { verificaToken, verificaGestore } = require('../middleware/authMiddleware');
 
-router.get('/:id', verificaToken, riepilogoController.getRiepilogoPrenotazioni);
+router.get('/:id', verificaToken, verificaGestore, riepilogoController.getRiepilogoPrenotazioni);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- require gestore authorization middleware on riepilogo route
- block riepilogo summaries unless requester id matches route parameter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68947ba3c7dc832890f09d5e8688e05e