### PR TITLE
Rinomina rotta prenotazioni gestore

### DIFF
--- a/backend/routes/gestoreRoutes.js
+++ b/backend/routes/gestoreRoutes.js
@@ -7,5 +7,5 @@ const { verificaToken, verificaGestore } = require('../middleware/authMiddleware
 router.put('/spazi/:id', verificaToken, verificaGestore, gestoreController.modificaSpazio);
 router.delete('/spazi/:id', verificaToken, verificaGestore, gestoreController.eliminaSpazio);
 router.post('/spazi/:id/disponibilita', verificaToken, verificaGestore, gestoreController.aggiungiDisponibilita);
-router.get('/prenotazioni/:gestore_id', verificaToken, verificaGestore, gestoreController.visualizzaPrenotazioniRicevute);
+router.get('/gestore/prenotazioni/:gestore_id', verificaToken, verificaGestore, gestoreController.visualizzaPrenotazioniRicevute);
 module.exports = router;


### PR DESCRIPTION
## Summary
- renames gestore prenotazioni endpoint to `/gestore/prenotazioni/:gestore_id`
- confirm existing prenotazioni routes still serve `/api/prenotazioni/...`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68947ef506b083288cb49b1c7128516e