### PR TITLE
Move space creation to gestore routes

### DIFF
--- a/backend/controllers/gestoreController.js
+++ b/backend/controllers/gestoreController.js
@@ -1,4 +1,8 @@
 const pool = require('../db');
+const spaziController = require('./spaziController');
+
+// 0. Aggiungi spazio (riusa la logica del controller degli spazi)
+exports.aggiungiSpazio = spaziController.aggiungiSpazio;
 
 // 1. Modifica spazio
 exports.modificaSpazio = async (req, res) => {

--- a/backend/routes/gestoreRoutes.js
+++ b/backend/routes/gestoreRoutes.js
@@ -4,6 +4,7 @@ const gestoreController = require('../controllers/gestoreController');
 const { verificaToken, verificaGestore } = require('../middleware/authMiddleware');
 
 
+router.post('/spazi', verificaToken, verificaGestore, gestoreController.aggiungiSpazio);
 router.put('/spazi/:id', verificaToken, verificaGestore, gestoreController.modificaSpazio);
 router.delete('/spazi/:id', verificaToken, verificaGestore, gestoreController.eliminaSpazio);
 router.post('/spazi/:id/disponibilita', verificaToken, verificaGestore, gestoreController.aggiungiDisponibilita);

--- a/backend/routes/spaziRoutes.js
+++ b/backend/routes/spaziRoutes.js
@@ -1,12 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const spaziController = require('../controllers/spaziController');
-const { verificaToken, verificaGestore } = require('../middleware/authMiddleware');
 
 // Recupera spazi per sede (accessibile a tutti)
 router.get('/:sede_id', spaziController.getSpaziPerSede);
-
-// Aggiungi spazio (solo per gestore)
-router.post('/', verificaToken, verificaGestore, spaziController.aggiungiSpazio);
 
 module.exports = router;

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -189,6 +189,7 @@ $(document).ready(function () {
       return;
     }
 
+    // Endpoint: POST /api/spazi (gestoreRoutes)
     $.ajax({
       url: `${API_BASE}/spazi`,
       method: 'POST',


### PR DESCRIPTION
## Summary
- Delegate spazio creation to gestore routes using existing controller logic
- Remove duplicate creation route from spazi routes
- Clarify frontend submission uses /api/spazi endpoint

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6894873dfeec8328af5da1ba212e9ff7