### PR TITLE
Unify booking summary response format

### DIFF
--- a/backend/controllers/riepilogoController.js
+++ b/backend/controllers/riepilogoController.js
@@ -10,7 +10,7 @@ exports.getRiepilogoPrenotazioni = async (req, res) => {
   try {
     // Query che aggrega il numero di prenotazioni per ogni spazio gestito dal gestore
     const result = await pool.query(
-      `SELECT 
+      `SELECT
          sedi.nome AS nome_sede,
          spazi.nome AS nome_spazio,
          spazi.image_url,
@@ -24,7 +24,12 @@ exports.getRiepilogoPrenotazioni = async (req, res) => {
       [gestoreId]
     );
 
-    res.json({ riepilogo: result.rows });
+    const riepilogo = result.rows.map(r => ({
+      ...r,
+      totale_prenotazioni: parseInt(r.totale_prenotazioni, 10) || 0,
+    }));
+
+    res.json({ riepilogo });
   } catch (err) {
     console.error('Errore recupero riepilogo prenotazioni:', err);
     res.status(500).json({ message: 'Errore del server' });

--- a/frontend/js/gestore.js
+++ b/frontend/js/gestore.js
@@ -84,45 +84,45 @@ $(document).ready(function () {
 
   caricaSpazi();
 
-  // Visualizza riepilogo prenotazioni aggregato
-  function caricaRiepilogo() {
-    $.ajax({
-      url: `${API_BASE}/riepilogo/${utente.id}`,
-      method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
-      success: function (data) {
-        console.log("Riepilogo dati ricevuti:", data);
-        const container = $('#riepilogoContainer');
-        container.empty();
+    // Visualizza riepilogo prenotazioni aggregato per ogni spazio
+    function caricaRiepilogo() {
+      $.ajax({
+        url: `${API_BASE}/riepilogo/${utente.id}`,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+        success: function (data) {
+          const container = $('#riepilogoContainer');
+          container.empty();
 
-        if (!data.riepilogo || !Array.isArray(data.riepilogo) || data.riepilogo.length === 0) {
-          container.html('<div class="alert alert-info">Nessuna prenotazione registrata nei tuoi spazi.</div>');
-          return;
-        }
+          if (!data.riepilogo || !Array.isArray(data.riepilogo) || data.riepilogo.length === 0) {
+            container.html('<div class="alert alert-info">Nessuna prenotazione registrata nei tuoi spazi.</div>');
+            return;
+          }
 
-        data.riepilogo.forEach(r => {
-          container.append(`
-            <div class="card mb-2">
-              <div class="row g-0 align-items-center">
-                <div class="col-md-3 text-center p-2">
-                  ${r.image_url ? `<img src="${r.image_url}" class="spazio-thumb" alt="${r.nome_spazio || 'Spazio'}" />` : ''}
-                </div>
-                <div class="col-md-9">
-                  <div class="card-body">
-                    🏢 <strong>${r.nome_sede || 'N/D'}</strong> – 🪑 ${r.nome_spazio || 'N/D'}<br>
-                    📊 Prenotazioni totali: ${r.totale_prenotazioni || 0}
+          data.riepilogo.forEach(r => {
+            const count = Number(r.totale_prenotazioni) || 0;
+            container.append(`
+              <div class="card mb-2">
+                <div class="row g-0 align-items-center">
+                  <div class="col-md-3 text-center p-2">
+                    ${r.image_url ? `<img src="${r.image_url}" class="spazio-thumb" alt="${r.nome_spazio || 'Spazio'}" />` : ''}
+                  </div>
+                  <div class="col-md-9">
+                    <div class="card-body">
+                      🏢 <strong>${r.nome_sede || 'N/D'}</strong> – 🪑 ${r.nome_spazio || 'N/D'}<br>
+                      📊 Prenotazioni totali: ${count}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          `);
-        });
-      },
-      error: function () {
-        $('#riepilogoContainer').html('<div class="alert alert-danger">Errore nel caricamento del riepilogo.</div>');
-      }
-    });
-  }
+            `);
+          });
+        },
+        error: function () {
+          $('#riepilogoContainer').html('<div class="alert alert-danger">Errore nel caricamento del riepilogo.</div>');
+        }
+      });
+    }
 
   caricaRiepilogo();
 


### PR DESCRIPTION
## Summary
- return booking summaries as aggregated counts
- parse aggregated counts in gestore dashboard and show totals

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6894873fb0388328a0c5375968ef58eb