### PR TITLE
Remove unused booking card image and style

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -431,11 +431,6 @@ button.btn-lg {
   margin-bottom: 10px;
 }
 
-.spazio-img {
-  height: 160px;
-  object-fit: cover;
-}
-
 .card-icons i {
   margin-right: 0.5rem;
   font-size: 1.2rem;

--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -113,7 +113,6 @@ $(document).ready(function () {
         const card = `
           <div class="col-md-4 mb-3">
             <div class="card h-100 shadow-sm">
-              <img src="https://via.placeholder.com/600x400?text=${encodeURIComponent(spazio.nome_spazio)}" class="spazio-img card-img-top" alt="${spazio.nome_spazio}">
               <div class="card-body d-flex flex-column">
                 <h5 class="card-title">${spazio.nome_spazio}</h5>
                 <p class="card-text flex-grow-1">${spazio.descrizione}</p>


### PR DESCRIPTION
## Summary
- Strip placeholder image from prenotazione card markup so cards only show textual details.
- Drop unused `.spazio-img` CSS block.

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894aad19110832882a025c8575125c9