### PR TITLE
docs: add booking and admin endpoints

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -65,13 +65,60 @@ Filtri disponibili su `/api/sedi`:
 
 ## 📅 Prenotazioni
 
-| Metodo | Endpoint               | Descrizione                                      |
-|--------|------------------------|--------------------------------------------------|
-| POST   | `/api/prenotazioni`    | Crea una nuova prenotazione (calcola e restituisce l'importo) |
-| GET    | `/api/prenotazioni`    | Elenca tutte le prenotazioni dell’utente loggato|
-| DELETE | `/api/prenotazioni/:id`| Annulla una prenotazione dell’utente loggato     |
+| Metodo | Endpoint                           | Descrizione                                                  |
+|--------|------------------------------------|--------------------------------------------------------------|
+| POST   | `/api/prenotazioni`                | Crea una nuova prenotazione (calcola e restituisce l'importo) |
+| GET    | `/api/prenotazioni`                | Elenca tutte le prenotazioni dell’utente loggato             |
+| GET    | `/api/prenotazioni/non-pagate`     | Prenotazioni dell’utente non ancora saldate                  |
+| PUT    | `/api/prenotazioni/:id`            | Modifica data e orari di una prenotazione esistente          |
+| DELETE | `/api/prenotazioni/:id`            | Annulla una prenotazione dell’utente loggato                 |
 
 **Body POST /api/prenotazioni:** `spazio_id`, `data`, `orario_inizio`, `orario_fine`
+
+**Esempio risposta GET `/api/prenotazioni/non-pagate`:**
+```json
+{
+  "prenotazioni": [
+    {
+      "id": 12,
+      "spazio_id": 3,
+      "data": "2025-01-10",
+      "orario_inizio": "09:00",
+      "orario_fine": "11:00",
+      "nome_spazio": "Sala Riunioni",
+      "nome_sede": "Sede Centrale",
+      "prezzo_orario": 20,
+      "importo": null
+    }
+  ]
+}
+```
+
+**Body PUT `/api/prenotazioni/:id`:** `data`, `orario_inizio`, `orario_fine`
+
+**Esempio richiesta PUT `/api/prenotazioni/12`:**
+```json
+{
+  "data": "2025-02-15",
+  "orario_inizio": "10:00",
+  "orario_fine": "12:00"
+}
+```
+
+**Esempio risposta:**
+```json
+{
+  "message": "Prenotazione aggiornata",
+  "prenotazione": {
+    "id": 12,
+    "spazio_id": 3,
+    "data": "2025-02-15",
+    "orario_inizio": "10:00",
+    "orario_fine": "12:00",
+    "utente_id": 5
+  }
+}
+```
 
 > **Nota di sicurezza:** l'ID dell'utente viene dedotto dal token di autenticazione e non va inviato nel body. Qualsiasi `utente_id` manipolato o incluso nella richiesta viene ignorato e la prenotazione sarà sempre associata all'utente autenticato.
 > Solo il proprietario può modificare o eliminare la propria prenotazione.
@@ -92,22 +139,75 @@ Filtri disponibili su `/api/sedi`:
 
 ## 📊 Dashboard Gestore
 
-| Metodo | Endpoint                             | Descrizione                                      |
-|--------|--------------------------------------|--------------------------------------------------|
-| GET    | `/api/sedi/gestore/:id`              | Visualizza sedi gestite dal gestore loggato      |
-| POST   | `/api/spazi`                         | Aggiunge uno spazio a una sede (gestore)         |
-| PUT    | `/api/spazi/:id`                     | Modifica uno spazio esistente                    |
-| DELETE | `/api/spazi/:id`                     | Elimina uno spazio                               |
-| POST   | `/api/spazi/:id/disponibilita`       | Aggiunge disponibilità a uno spazio              |
+| Metodo | Endpoint                                      | Descrizione                                      |
+|--------|-----------------------------------------------|--------------------------------------------------|
+| GET    | `/api/sedi/gestore/:id`                       | Visualizza sedi gestite dal gestore loggato      |
+| GET    | `/api/gestore/prenotazioni/:gestore_id`       | Prenotazioni ricevute per le proprie sedi        |
+| GET    | `/api/riepilogo/:id`                          | Riepilogo prenotazioni per spazio                |
+| POST   | `/api/spazi`                                  | Aggiunge uno spazio a una sede (gestore)         |
+| PUT    | `/api/spazi/:id`                              | Modifica uno spazio esistente                    |
+| DELETE | `/api/spazi/:id`                              | Elimina uno spazio                               |
+| POST   | `/api/spazi/:id/disponibilita`                | Aggiunge disponibilità a uno spazio              |
+
+**Esempio risposta GET `/api/gestore/prenotazioni/7`:**
+```json
+{
+  "prenotazioniRicevute": [
+    {
+      "id": 9,
+      "utente_id": 4,
+      "spazio_id": 2,
+      "data": "2025-01-20",
+      "orario_inizio": "14:00",
+      "orario_fine": "15:00",
+      "nome_utente": "Mario Rossi",
+      "nome_spazio": "Ufficio 1"
+    }
+  ]
+}
+```
+
+**Esempio risposta GET `/api/riepilogo/7`:**
+```json
+{
+  "riepilogo": [
+    {
+      "nome_sede": "Sede Centrale",
+      "nome_spazio": "Sala Riunioni",
+      "image_url": "https://esempio.com/sala.jpg",
+      "totale_prenotazioni": 12
+    }
+  ]
+}
+```
 
 ---
 
 ## 🛠️ Funzionalità Amministratore
 
-| Metodo | Endpoint                    | Descrizione                             |
-|--------|-----------------------------|-----------------------------------------|
-| GET    | `/api/admin/utenti`         | Visualizza tutti gli utenti (admin)     |
-| DELETE | `/api/admin/utenti/:id`     | Elimina un utente (admin)               |
+| Metodo | Endpoint                    | Descrizione                                             |
+|--------|-----------------------------|---------------------------------------------------------|
+| GET    | `/api/admin/utenti`         | Visualizza tutti gli utenti (admin)                     |
+| GET    | `/api/admin/sedi`           | Visualizza tutte le sedi (admin)                        |
+| DELETE | `/api/admin/utenti/:id`     | Elimina un utente (admin)                               |
+| DELETE | `/api/admin/sedi/:id`       | Elimina una sede con spazi, prenotazioni e pagamenti    |
+
+**Esempio risposta GET `/api/admin/sedi`:**
+```json
+[
+  {
+    "id": 1,
+    "nome": "Sede Centrale",
+    "citta": "Roma",
+    "gestore_id": 7
+  }
+]
+```
+
+**Esempio risposta DELETE `/api/admin/sedi/1`:**
+```json
+{ "message": "Sede eliminata" }
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document new booking endpoints for unpaid reservations and updates
- expand admin and manager sections with sede, riepilogo, and prenotazioni routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894b12d43f08328a3aaeb6d70df364f