### PR TITLE
feat: add authenticated profile endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Adatta i valori alle tue impostazioni locali.
 
 La specifica completa delle API è disponibile in [docs/api-spec.md](docs/api-spec.md).
 
+### Esempio: recupero profilo autenticato
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/api/utente/me
+```
+
 ## Avvio del frontend
 
 Le pagine statiche sono nella cartella `frontend`.

--- a/backend/README.txt
+++ b/backend/README.txt
@@ -62,8 +62,14 @@
 - POST   /api/login               → Login utente
 
 👤 Utente:
-- GET    /api/utente/:id          → Profilo utente
+- GET    /api/utente/me           → Profilo dell'utente autenticato
 - GET    /api/prenotazioni        → Prenotazioni utente
+
+Esempio richiesta profilo autenticato:
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/api/utente/me
+```
 
 🏢 Sedi e spazi:
 - GET    /api/sedi                → Elenco sedi

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -24,6 +24,27 @@ exports.getProfilo = async (req, res) => {
   }
 };
 
+// Recupera il profilo dell'utente autenticato
+exports.getProfiloAutenticato = async (req, res) => {
+  const id = req.utente.id;
+
+  try {
+    const result = await pool.query(
+      'SELECT id, nome, email, ruolo FROM utenti WHERE id = $1',
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Utente non trovato' });
+    }
+
+    res.json({ utente: result.rows[0] });
+  } catch (err) {
+    console.error('Errore recupero profilo autenticato:', err);
+    res.status(500).json({ message: 'Errore del server' });
+  }
+};
+
 // Aggiorna il profilo utente
 exports.updateProfilo = async (req, res) => {
   const id = req.utente.id;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -7,6 +7,12 @@ const validate = require('../middleware/validateInput');
 // DEPRECATO: la rotta /profilo/:id è stata sostituita da /api/utente/me
 router.get('/profilo/:id', userController.getProfilo);
 
+router.get(
+  '/utente/me',
+  authMiddleware.verificaToken,
+  userController.getProfiloAutenticato
+);
+
 router.put(
   '/utente/me',
   authMiddleware.verificaToken,

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -24,6 +24,25 @@ Le rotte che richiedono autenticazione devono includere un token/sessione nel cl
 | GET    | `/api/utente/me`  | Recupera i dati del profilo dell’utente loggato |
 | PUT    | `/api/utente/me`  | Aggiorna i dati del proprio profilo utente   |
 
+**Esempio GET `/api/utente/me`:**
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://localhost:3000/api/utente/me
+```
+
+Risposta:
+
+```json
+{
+  "utente": {
+    "id": 1,
+    "nome": "Mario Rossi",
+    "email": "mario@example.com",
+    "ruolo": "utente"
+  }
+}
+```
+
 **Body PUT /api/utente/me:**
 
 - `nome` e/o `password` (almeno uno dei due campi)


### PR DESCRIPTION
## Summary
- add `/utente/me` route with auth to read logged-in profile
- implement `getProfiloAutenticato` controller
- document usage of new profile endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894b14c51e4832897b7d5c9b2cba94d