### PR TITLE
feat: integrate stripe payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=coworkspace
 JWT_SECRET=supersegreto
+# Chiave segreta Stripe per i pagamenti
+STRIPE_SECRET_KEY=sk_test_...
 ```
 
 Adatta i valori alle tue impostazioni locali.
+
+Per il frontend è inoltre necessario esporre la chiave pubblicabile Stripe (`STRIPE_PUBLISHABLE_KEY`) come variabile globale `window.STRIPE_PUBLISHABLE_KEY` nelle pagine che effettuano pagamenti.
 
 ## Avvio del database
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.16.3"
+        "pg": "^8.16.3",
+        "stripe": "^18.4.0"
       }
     },
     "node_modules/accepts": {
@@ -1094,6 +1095,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.4.0.tgz",
+      "integrity": "sha512-LKFeDnDYo4U/YzNgx2Lc9PT9XgKN0JNF1iQwZxgkS4lOw5NunWCnzyH5RhTlD3clIZnf54h7nyMWkS8VXPmtTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/toidentifier": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "stripe": "^18.4.0"
   },
   "description": ""
 }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -148,7 +148,7 @@ Filtri disponibili su `/api/sedi`:
 
 | Metodo | Endpoint                 | Descrizione                                                         |
 |--------|--------------------------|---------------------------------------------------------------------|
-| POST   | `/api/pagamenti/pagamento`         | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`) – l'importo è letto dalla prenotazione |
+| POST   | `/api/pagamenti/pagamento`         | Esegue il pagamento di una prenotazione (`prenotazione_id`, `metodo`, `token` per pagamenti carta) – l'importo è letto dalla prenotazione |
 | GET    | `/api/pagamenti/storico` | Restituisce lo storico pagamenti dell'utente (parametro opzionale `limit`, default 5) |
 
 **Query params GET `/api/pagamenti/storico`:**

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -61,6 +61,8 @@
                     <option value="bancomat">💳 Bancomat</option>
                   </select>
                 </div>
+                <div id="card-element" class="mb-3 d-none"></div>
+                <div id="card-errors" class="text-danger mb-3"></div>
                 <p id="importoDaPagare" class="fw-bold fs-4 text-end"></p>
 
                 <button type="submit" class="btn btn-primary btn-lg w-100 position-relative">
@@ -109,6 +111,7 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://js.stripe.com/v3"></script>
     <script src="js/menu.js"></script>
     <script src="js/pagamento.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- integrate Stripe in backend to process card payments via tokens
- expose Stripe card form and tokenization on payment page
- document Stripe env vars and token requirement in API spec

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm install --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6894b4b8fa9083288057dd86f20f111d