### PR TITLE
Expose Stripe publishable key to frontend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const express = require('express');
 const cors = require('cors');
 const app = express();
 const PORT = process.env.PORT || 3000;
+const STRIPE_PUBLISHABLE_KEY = process.env.STRIPE_PUBLISHABLE_KEY;
 
 // Middleware
 app.use(cors());
@@ -13,6 +14,11 @@ app.use(express.static(path.join(__dirname, '../frontend')));
 // Debug route to test if endpoint is accessible
 app.get('/api/test', (req, res) => {
   res.json({ message: 'Server is running' });
+});
+
+// Configurazione Stripe
+app.get('/config/stripe', (_, res) => {
+  res.json({ publishableKey: STRIPE_PUBLISHABLE_KEY });
 });
 
 // Rotte

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -113,6 +113,16 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://js.stripe.com/v3"></script>
     <script src="js/menu.js"></script>
-    <script src="js/pagamento.js"></script>
+    <script>
+      fetch('/config/stripe')
+        .then(res => res.json())
+        .then(data => {
+          window.STRIPE_PUBLISHABLE_KEY = data.publishableKey;
+          const script = document.createElement('script');
+          script.src = 'js/pagamento.js';
+          document.body.appendChild(script);
+        })
+        .catch(err => console.error('Errore configurazione Stripe:', err));
+    </script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- add server endpoint exposing `STRIPE_PUBLISHABLE_KEY`
- fetch publishable key before loading payment script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894c87f6ad083289120026b5ed9b47e