### PR TITLE
Store provider details for payments

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -55,6 +55,9 @@ exports.effettuaPagamento = async (req, res) => {
       return res.status(400).json({ message: 'Prenotazione già pagata' });
     }
 
+    let providerId = null;
+    let stato = null;
+
     // Se il metodo è carta utilizziamo Stripe per eseguire il pagamento
     if (metodo === 'carta') {
       if (!token) {
@@ -73,19 +76,22 @@ exports.effettuaPagamento = async (req, res) => {
         await pool.query('ROLLBACK');
         return res.status(400).json({ message: 'Pagamento non riuscito' });
       }
+
+      providerId = charge.id;
+      stato = charge.status;
     }
 
     await pool.query(
-      `INSERT INTO pagamenti (prenotazione_id, importo, metodo, timestamp)
-       VALUES ($1, $2, $3, NOW())`,
-      [prenotazione_id, importo, metodo]
+      `INSERT INTO pagamenti (prenotazione_id, importo, metodo, provider_id, stato, timestamp)
+       VALUES ($1, $2, $3, $4, $5, NOW())`,
+      [prenotazione_id, importo, metodo, providerId, stato]
     );
 
     await pool.query('COMMIT');
 
     res.status(201).json({
       message: 'Pagamento registrato',
-      pagamento: { prenotazione_id, importo, metodo }
+      pagamento: { prenotazione_id, importo, metodo, provider_id: providerId, stato }
     });
   } catch (err) {
     await pool.query('ROLLBACK');

--- a/backend/db/migrations/[timestamp]_create_pagamenti_table.sql
+++ b/backend/db/migrations/[timestamp]_create_pagamenti_table.sql
@@ -1,7 +1,9 @@
 CREATE TABLE IF NOT EXISTS pagamenti (
   id SERIAL PRIMARY KEY,
   prenotazione_id INTEGER REFERENCES prenotazioni(id),
-  "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  importo DECIMAL(10,2) NOT NULL,
   metodo VARCHAR(50) NOT NULL,
-  importo DECIMAL(10,2) NOT NULL
+  provider_id VARCHAR(255),
+  stato VARCHAR(20),
+  "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/backend/db/migrations/create_pagamenti.sql
+++ b/backend/db/migrations/create_pagamenti.sql
@@ -1,7 +1,9 @@
 CREATE TABLE IF NOT EXISTS pagamenti (
     id SERIAL PRIMARY KEY,
     prenotazione_id INTEGER REFERENCES prenotazioni(id),
-    "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    importo DECIMAL(10,2) NOT NULL,
     metodo VARCHAR(50) NOT NULL,
-    importo DECIMAL(10,2) NOT NULL
+    provider_id VARCHAR(255),
+    stato VARCHAR(20),
+    "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -58,6 +58,8 @@ CREATE TABLE pagamenti (
   prenotazione_id INTEGER NOT NULL REFERENCES prenotazioni(id) ON DELETE CASCADE,
   importo NUMERIC(7,2) NOT NULL,
   metodo VARCHAR(20) NOT NULL CHECK (metodo IN ('paypal','satispay','carta','bancomat')),
+  provider_id VARCHAR(255),
+  stato VARCHAR(20),
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add provider_id and status fields to pagamenti table and migrations
- capture Stripe charge id and status and store them with each payment

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894c88395e88328974a22c607950122