### PR TITLE
feat: limit auth and payment requests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "stripe": "^18.4.0"
@@ -324,6 +325,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -483,6 +502,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "stripe": "^18.4.0"

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,8 +2,20 @@ const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 const express = require('express');
 const cors = require('cors');
+const rateLimit = require('express-rate-limit');
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// Rate limiting
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100
+});
+
+const paymentLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100
+});
 
 // Middleware
 app.use(cors());
@@ -17,7 +29,7 @@ app.get('/api/test', (req, res) => {
 
 // Rotte
 app.get('/', (_, res) => res.sendFile(path.join(__dirname, '../frontend/index.html')));
-app.use('/api', require('./routes/authRoutes'));           // Login, registrazione, logout
+app.use('/api', authLimiter, require('./routes/authRoutes'));           // Login, registrazione, logout
 app.use('/api', require('./routes/userRoutes'));           // Profilo utente
 app.use('/api/sedi', require('./routes/sediRoutes'));
 app.use('/api/spazi', require('./routes/spaziRoutes'));
@@ -25,7 +37,7 @@ const prenotazioniRoutes = require('./routes/prenotazioniRoutes');
 const pagamentiRoutes = require('./routes/pagamentiRoutes');
 
 app.use('/api/prenotazioni', prenotazioniRoutes);
-app.use('/api/pagamenti', pagamentiRoutes);
+app.use('/api/pagamenti', paymentLimiter, pagamentiRoutes);
 app.use('/api/riepilogo', require('./routes/riepilogoRoutes'));
 app.use('/api', require('./routes/gestoreRoutes'));        // Dashboard gestore
 app.use('/api/admin', require('./routes/adminRoutes'));    // Area admin


### PR DESCRIPTION
## Summary
- install express-rate-limit
- protect auth and payment endpoints with rate limiter (100 requests per 15 min)

## Testing
- `cd backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894c891f6a48328bd5bb3286312b5bd