### PR TITLE
Disable card payments when Stripe key missing

### DIFF
--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -12,6 +12,14 @@ $(document).ready(function () {
     return;
   }
 
+  if (!stripe) {
+    $('#metodo option[value="carta"]').prop('disabled', true)
+      .text('💳 Carta di Credito (non disponibile)');
+    $('#alertPagamento').html(
+      '<div class="alert alert-warning">Il pagamento con carta non è al momento disponibile.</div>'
+    );
+  }
+
   let prenotazioni = []; // Variabile per memorizzare le prenotazioni
 
   function mostraRiepilogoPrenotazione(prenotazione) {


### PR DESCRIPTION
## Summary
- Hide credit card option if Stripe key is missing and show a warning message

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8a27b78832887e3ac556e2553e9