### PR TITLE
Fix payment controller structure and clean routes

### DIFF
--- a/backend/routes/pagamentiRoutes.js
+++ b/backend/routes/pagamentiRoutes.js
@@ -6,7 +6,4 @@ const { verificaToken } = require('../middleware/authMiddleware'); // 👈 IMPOR
 router.post('/pagamento', verificaToken, pagamentiController.effettuaPagamento); // 👈 OK
 router.get('/storico', verificaToken, pagamentiController.storicoPagamenti);
 
-// Assicurati che la funzione esista e sia esportata correttamente
-router.post('/crea', pagamentiController.creaPagamento); // nomeFunzione deve essere una funzione
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- properly close pagamenti controller catch block and effettuaPagamento
- export storicoPagamenti separately
- remove obsolete /crea route from pagamenti routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68962e731dd883289a7e1760ee20f1b1