### PR TITLE
fix: gestisci id provider e stato nei pagamenti

### DIFF
--- a/backend/controllers/pagamentiController.js
+++ b/backend/controllers/pagamentiController.js
@@ -1,6 +1,7 @@
 require('dotenv').config(); // Carica variabili d'ambiente dal file .env
 const pool = require('../db');
 const Stripe = require('stripe');
+const logger = require('../utils/logger');
 
 // Controlla che la chiave sia presente
 if (!process.env.STRIPE_SECRET_KEY) {
@@ -14,6 +15,8 @@ exports.effettuaPagamento = async (req, res) => {
   const { prenotazione_id, metodo, paymentIntentId } = req.body;
   const utente_id = req.utente.id;
   let importoCalcolato = null;
+  let providerId = null;
+  let stato = null;
 
   const metodiValidi = ['paypal', 'satispay', 'carta', 'bancomat'];
   if (!metodiValidi.includes(metodo)) {
@@ -127,8 +130,8 @@ exports.effettuaPagamento = async (req, res) => {
         return res.status(400).json({ message: 'Pagamento non riuscito' });
       }
 
-      providerId = charge.id;
-      stato = charge.status;
+      providerId = paymentIntent.id;
+      stato = paymentIntent.status;
     }
 
     await pool.query(


### PR DESCRIPTION
## Summary
- importa logger nel controller pagamenti
- inizializza providerId e stato all'inizio della funzione effettuaPagamento
- usa paymentIntent per valorizzare providerId e stato

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68962e74247c83288824172d0a9390e5