### PR TITLE
feat: add configurable API base for auth

### DIFF
--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -1,3 +1,5 @@
+const API_BASE = window.API_BASE || '/api';
+
 $(function () {
   // Mostra il form di login
   $('#btnShowLogin').click(function () {
@@ -35,7 +37,7 @@ $(function () {
 
     // Chiamata AJAX per login
     $.ajax({
-      url: 'http://localhost:3000/api/login', 
+      url: `${API_BASE}/login`,
       method: 'POST',
       contentType: 'application/json',
       data: JSON.stringify({ email, password }),
@@ -82,7 +84,7 @@ $(function () {
 
     // Chiamata AJAX per registrazione
     $.ajax({
-      url: 'http://localhost:3000/api/register',
+      url: `${API_BASE}/register`,
       method: 'POST',
       contentType: 'application/json',
       data: JSON.stringify({ nome, email, password, ruolo }),


### PR DESCRIPTION
## Summary
- allow overriding API base URL via `window.API_BASE`
- use base URL when calling login and register endpoints

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689638d2a2ec8328abea48435ba2dbf3