### PR TITLE
chore: add backend docker build setup

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+logs
+*.log
+cert
+certs

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE ${PORT}
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- add Dockerfile for backend service using Node 18
- ignore runtime artifacts when building backend container

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896770f94b48328b81b3b065ccb76ec