### PR TITLE
chore: set API base URL

### DIFF
--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -1,3 +1,5 @@
+// Base URL for the backend API
+window.API_BASE = 'https://backend.example.com/api';
 const API_BASE = window.API_BASE || '/api';
 
 $(document).ready(function () {


### PR DESCRIPTION
## Summary
- set `window.API_BASE` in `prenotazione.js` to a placeholder backend endpoint

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689677128ce083289016f457c7a1d5e8