### PR TITLE
Add Stripe secret key configuration to backend

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,8 @@
-DB_USER=admin
-DB_PASSWORD=examplepass123
-DB_HOST=example-rds-endpoint.us-east-1.rds.amazonaws.com
+PORT=3000
+DB_USER=postgres
+DB_PASSWORD=password
+DB_HOST=localhost
 DB_PORT=5432
-DB_NAME=coworkdb
+DB_NAME=coworkspace
+JWT_SECRET=supersegreto
+STRIPE_SECRET_KEY=sk_test_placeholder


### PR DESCRIPTION
## Summary
- configure backend environment with Stripe secret key and default settings

## Testing
- `npm test` (fails: no test specified)
- `npm start` followed by `curl -k -L https://localhost:3443/api/test`

------
https://chatgpt.com/codex/tasks/task_e_689783dc36848328b31cb09143279db6