### PR TITLE
Use dynamic API base URL

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -60,6 +60,7 @@
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/menu.js"></script>
   <script src="js/admin.js"></script>
 </body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -50,6 +50,7 @@
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/menu.js"></script>
   <script src="js/dashboard.js"></script>
 </body>

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -16,7 +16,7 @@ $(document).ready(function () {
   // Funzione per caricare la lista utenti dal backend
   function caricaUtenti() {
     $.ajax({
-      url: 'http://localhost:3000/api/admin/utenti',
+      url: `${API_BASE_URL}/api/admin/utenti`,
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
       success: function (utenti) {
@@ -46,7 +46,7 @@ $(document).ready(function () {
   // Funzione per caricare la lista sedi dal backend
   function caricaSedi() {
     $.ajax({
-      url: 'http://localhost:3000/api/admin/sedi',
+      url: `${API_BASE_URL}/api/admin/sedi`,
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
       success: function (sedi) {
@@ -78,7 +78,7 @@ $(document).ready(function () {
     const id = $(this).data('id');
     if (confirm('Sei sicuro di voler eliminare questo utente?')) {
       $.ajax({
-        url: `http://localhost:3000/api/admin/utenti/${id}`,
+        url: `${API_BASE_URL}/api/admin/utenti/${id}`,
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
         success: function () {
@@ -96,7 +96,7 @@ $(document).ready(function () {
     const id = $(this).data('id');
     if (confirm('Sei sicuro di voler eliminare questa sede?')) {
       $.ajax({
-        url: `http://localhost:3000/api/admin/sedi/${id}`,
+        url: `${API_BASE_URL}/api/admin/sedi/${id}`,
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
         success: function () {

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,0 +1,1 @@
+const API_BASE_URL = window.location.origin;

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
     console.log('Token inviato:', token); // DEBUG: verifica token
 
     $.ajax({
-      url: 'http://localhost:3000/api/prenotazioni',
+      url: `${API_BASE_URL}/api/prenotazioni`,
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
       success: function (data) {
@@ -71,7 +71,7 @@ $(document).ready(function () {
           if (!nuovoFine) return;
 
           $.ajax({
-            url: `http://localhost:3000/api/prenotazioni/${id}`,
+            url: `${API_BASE_URL}/api/prenotazioni/${id}`,
             method: 'PUT',
             contentType: 'application/json',
             headers: { Authorization: `Bearer ${token}` },
@@ -91,7 +91,7 @@ $(document).ready(function () {
           if (!confirm('Sei sicuro di voler annullare questa prenotazione?')) return;
 
           $.ajax({
-            url: `http://localhost:3000/api/prenotazioni/${id}`,
+            url: `${API_BASE_URL}/api/prenotazioni/${id}`,
             method: 'DELETE',
             headers: { Authorization: `Bearer ${token}` },
             success: function () {

--- a/frontend/js/pagamento.js
+++ b/frontend/js/pagamento.js
@@ -1,4 +1,4 @@
-const API_BASE = window.API_BASE || '/api';
+const API_BASE = `${API_BASE_URL}/api`;
 
 $(document).ready(function () {
   const token = localStorage.getItem('token');
@@ -228,7 +228,7 @@ $(document).ready(function () {
       if (metodo === 'carta' && stripe) {
         // Crea il PaymentIntent sul backend
         const initRes = await $.ajax({
-          url: 'http://localhost:3000/api/pagamenti/pagamento',
+          url: `${API_BASE}/pagamenti/pagamento`,
           method: 'POST',
           contentType: 'application/json',
           headers: { Authorization: `Bearer ${token}` },
@@ -249,7 +249,7 @@ $(document).ready(function () {
 
         // Registra il pagamento sul backend
         const finalRes = await $.ajax({
-          url: 'http://localhost:3000/api/pagamenti/pagamento',
+          url: `${API_BASE}/pagamenti/pagamento`,
           method: 'POST',
           contentType: 'application/json',
           headers: { Authorization: `Bearer ${token}` },
@@ -275,7 +275,7 @@ $(document).ready(function () {
         caricaStoricoPagamenti(); // Aggiorna lo storico
       } else {
         const res = await $.ajax({
-          url: 'http://localhost:3000/api/pagamenti/pagamento',
+          url: `${API_BASE}/pagamenti/pagamento`,
           method: 'POST',
           contentType: 'application/json',
           headers: { Authorization: `Bearer ${token}` },

--- a/frontend/js/profilo.js
+++ b/frontend/js/profilo.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
     const password = $('#nuovaPassword').val();
 
     $.ajax({
-      url: 'http://localhost:3000/api/utente/me',
+      url: `${API_BASE_URL}/api/utente/me`,
       method: 'PUT',
       contentType: 'application/json',
       headers: { Authorization: `Bearer ${token}` },

--- a/frontend/pagamento.html
+++ b/frontend/pagamento.html
@@ -112,6 +112,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://js.stripe.com/v3"></script>
+    <script src="js/config.js"></script>
     <script src="js/menu.js"></script>
     <script>
       fetch('/config/stripe')

--- a/frontend/profilo.html
+++ b/frontend/profilo.html
@@ -54,6 +54,7 @@
 
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/menu.js"></script>
   <script src="js/profilo.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- centralize API base URL in new `config.js` so requests work over HTTP and HTTPS
- replace hardcoded `http://localhost:3000` URLs in admin, dashboard, profile and payment scripts with `${API_BASE_URL}/api/...`
- load `config.js` on relevant HTML pages to avoid mixed-content issues

## Testing
- `curl -L -k http://localhost:3000/api/test`
- `curl -k https://localhost:3443/api/test`
- `for page in dashboard admin profilo pagamento; do curl -s -L -k http://localhost:3000/${page}.html | head -n 2; curl -s -k https://localhost:3443/${page}.html | head -n 2; done`


------
https://chatgpt.com/codex/tasks/task_e_6897871a420c83289baeccf85beeebb5