### PR TITLE
docs: document external payment fields

### DIFF
--- a/database/README-db.md
+++ b/database/README-db.md
@@ -98,7 +98,9 @@ Rappresenta una prenotazione effettuata da un utente su uno spazio.
 
 ### 🔹 `Pagamento`
 
-Dati relativi al pagamento associato a una prenotazione.
+Raccoglie i dati di pagamento associati a una prenotazione,
+inclusi l'identificativo della transazione esterna e lo stato
+del pagamento.
 
 | Campo             | Tipo         | Descrizione                          |
 |-------------------|--------------|--------------------------------------|
@@ -106,6 +108,8 @@ Dati relativi al pagamento associato a una prenotazione.
 | `prenotazione_id` | INTEGER      | FK → `Prenotazione(id)`              |
 | `importo`         | NUMERIC(7,2) | Importo totale                       |
 | `metodo`          | VARCHAR(20)  | Metodo usato (`paypal`, `satispay`, `carta`, `bancomat`) |
+| `provider_id`     | VARCHAR(255) | ID della transazione esterna         |
+| `stato`           | VARCHAR(20)  | Stato del pagamento (es. `succeeded`, `pagato`) |
 | `timestamp`       | TIMESTAMP    | Data e ora del pagamento             |
 
 


### PR DESCRIPTION
## Summary
- document external transaction identifier and payment status in database docs

## Testing
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf3895cc8328b2a0de2c97ea7dcc