### PR TITLE
Use 'nome' for user validation

### DIFF
--- a/backend/middleware/validateInput.js
+++ b/backend/middleware/validateInput.js
@@ -1,7 +1,7 @@
 // backend/middleware/validateInput.js
 function validateRegister(req, res, next) {
-  const { username, email, password } = req.body;
-  if (!username || !email || !password) {
+  const { nome, email, password } = req.body;
+  if (!nome || !email || !password) {
     return res.status(400).json({ error: 'Campi mancanti per la registrazione' });
   }
   next();
@@ -16,8 +16,8 @@ function validateLogin(req, res, next) {
 }
 
 function validateUpdateProfilo(req, res, next) {
-  const { username, email } = req.body;
-  if (!username && !email) {
+  const { nome, email } = req.body;
+  if (!nome && !email) {
     return res.status(400).json({ error: 'Nessun campo da aggiornare' });
   }
   next();


### PR DESCRIPTION
## Summary
- validate registration using `nome` instead of `username`
- update profile validation to accept `nome`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Errore di connessione al database)*

------
https://chatgpt.com/codex/tasks/task_e_68a06a679904832881a42675a5beacff