### PR TITLE
feat: update API base URL in prenotazione

### DIFF
--- a/frontend/js/prenotazione.js
+++ b/frontend/js/prenotazione.js
@@ -1,5 +1,7 @@
 // Base URL per le chiamate API al backend
-window.API_BASE = 'https://backend.example.com/api';
+// Può essere configurato per ambienti diversi impostando la variabile globale `window.API_BASE`
+// (ad esempio tramite un file di configurazione o una variabile d'ambiente)
+window.API_BASE = window.API_BASE || 'https://localhost:3443/api';
 const API_BASE = window.API_BASE || '/api';
 
 $(document).ready(function () {


### PR DESCRIPTION
## Summary
- point frontend prenotazione.js at local backend endpoint
- allow API base URL to be configured via `window.API_BASE`

## Testing
- `npm test` (fails: Error: no test specified)
- `curl -I https://localhost:3443/api/disponibilita` (connection refused: backend not running)


------
https://chatgpt.com/codex/tasks/task_e_68a07606da3c83289b6565ad7efea14c