### PR TITLE
feat: enforce strong password validation

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -14,6 +14,14 @@ exports.register = async (req, res) => {
       return res.status(400).json({ message: 'Email già registrata' });
     }
 
+    const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!passwordRegex.test(password)) {
+      return res.status(400).json({
+        message:
+          'La password deve contenere almeno 8 caratteri, una lettera maiuscola, un numero e un carattere speciale',
+      });
+    }
+
     const hashedPassword = await bcrypt.hash(password, 10);
 
     const result = await pool.query(

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -62,6 +62,13 @@ exports.updateProfilo = async (req, res) => {
 
     // Se viene fornita una nuova password, hashala
     if (password) {
+      const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+      if (!passwordRegex.test(password)) {
+        return res.status(400).json({
+          message:
+            'La password deve contenere almeno 8 caratteri, una lettera maiuscola, un numero e un carattere speciale',
+        });
+      }
       hashedPassword = await bcrypt.hash(password, 10);
     } else {
       // Altrimenti recupera la password attuale dal database

--- a/backend/middleware/validateInput.js
+++ b/backend/middleware/validateInput.js
@@ -4,6 +4,15 @@ function validateRegister(req, res, next) {
   if (!nome || !email || !password) {
     return res.status(400).json({ error: 'Campi mancanti per la registrazione' });
   }
+
+  const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+  if (!passwordRegex.test(password)) {
+    return res.status(400).json({
+      error:
+        'La password deve contenere almeno 8 caratteri, una lettera maiuscola, un numero e un carattere speciale',
+    });
+  }
+
   next();
 }
 


### PR DESCRIPTION
## Summary
- validate registration password with regex in middleware
- enforce strong password check before saving new users
- validate updated passwords in profile updates

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0abf4240083289d0779937e7cda8c