### PR TITLE
docs: add password complexity requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Per il frontend è inoltre necessario esporre la chiave pubblicabile Stripe (`ST
 | POST   | `/api/pagamento`         | Esegue il pagamento di una prenotazione          |
 | GET    | `/api/pagamenti/storico` | Restituisce lo storico pagamenti dell'utente    |
 
+### Requisiti password
+
+- La password deve contenere almeno 8 caratteri, includendo una lettera maiuscola, una minuscola e un numero.
+
 La specifica completa delle API è disponibile in [docs/api-spec.md](docs/api-spec.md).
 
 ### Esempio: recupero profilo autenticato

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -15,6 +15,17 @@ Le rotte che richiedono autenticazione devono includere un token/sessione nel cl
 | POST   | `/api/login`     | Login e generazione di token/sessione       |
 | GET    | `/api/logout`    | Logout e distruzione sessione               |
 
+**Body POST `/api/register`:**
+
+- `nome`, `email`, `password`, `ruolo` (opzionale)
+- La password deve contenere almeno 8 caratteri, includendo una lettera maiuscola, una minuscola e un numero.
+
+**Risposte:**
+
+- `201 Created` utente registrato
+- `400 Bad Request` se i dati sono mancanti o se la password non rispetta i requisiti di complessità
+- `500 Internal Server Error`
+
 ---
 
 ## 👤 Utente – Profilo
@@ -46,12 +57,13 @@ Risposta:
 **Body PUT /api/utente/me:**
 
 - `nome` e/o `password` (almeno uno dei due campi)
+- La password deve contenere almeno 8 caratteri, includendo una lettera maiuscola, una minuscola e un numero.
 - richiede token di autenticazione nel header `Authorization`
 
 **Risposte:**
 
 - `200 OK` profilo aggiornato
-- `400 Bad Request` body mancante o non valido
+- `400 Bad Request` body mancante o non valido o password non conforme ai requisiti di complessità
 - `401 Unauthorized` token assente o non valido
 - `500 Internal Server Error`
 


### PR DESCRIPTION
## Summary
- document password complexity for registration and profile update
- note 400 error when requirement not met

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac8b01c88328a5033593fd46bee0