### PR TITLE
Allow password-only profile updates

### DIFF
--- a/backend/middleware/validateInput.js
+++ b/backend/middleware/validateInput.js
@@ -25,8 +25,8 @@ function validateLogin(req, res, next) {
 }
 
 function validateUpdateProfilo(req, res, next) {
-  const { nome, email } = req.body;
-  if (!nome && !email) {
+  const { nome, email, password } = req.body;
+  if (!nome && !email && !password) {
     return res.status(400).json({ error: 'Nessun campo da aggiornare' });
   }
   next();


### PR DESCRIPTION
## Summary
- include `password` in profile update validation
- permit updates when only `password` is provided

## Testing
- `npm test`
- manual middleware test for `PUT /api/utente/me` with only `password`

------
https://chatgpt.com/codex/tasks/task_e_68a0b27b12fc8328bfced2ea177cea5c