### PR TITLE
Add Terraform modules for AWS infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ coverage/
 # OS files
 .DS_Store
 
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+**/.terraform/*

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  repository_name = var.ecr_repository_name
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  identifier             = var.rds_identifier
+  username               = var.rds_username
+  password               = var.rds_password
+  subnet_ids             = var.rds_subnet_ids
+  vpc_security_group_ids = var.rds_vpc_security_group_ids
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  cluster_name = var.ecs_cluster_name
+}
+
+module "s3" {
+  source = "./modules/s3"
+
+  bucket_name = var.s3_bucket_name
+}
+
+module "cloudfront" {
+  source = "./modules/cloudfront"
+
+  origin_bucket_domain_name = module.s3.bucket_domain_name
+}

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudfront_distribution" "this" {
+  enabled = true
+
+  origin {
+    domain_name = var.origin_bucket_domain_name
+    origin_id   = "s3-origin"
+
+    s3_origin_config {
+      origin_access_identity = ""
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-origin"
+    viewer_protocol_policy = "allow-all"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/infra/modules/cloudfront/outputs.tf
+++ b/infra/modules/cloudfront/outputs.tf
@@ -1,0 +1,9 @@
+output "domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.domain_name
+}
+
+output "arn" {
+  description = "ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.arn
+}

--- a/infra/modules/cloudfront/variables.tf
+++ b/infra/modules/cloudfront/variables.tf
@@ -1,0 +1,4 @@
+variable "origin_bucket_domain_name" {
+  description = "Domain name of the S3 bucket origin"
+  type        = string
+}

--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -1,0 +1,3 @@
+resource "aws_ecr_repository" "this" {
+  name = var.repository_name
+}

--- a/infra/modules/ecr/outputs.tf
+++ b/infra/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "URL of the ECR repository"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "ARN of the ECR repository"
+  value       = aws_ecr_repository.this.arn
+}

--- a/infra/modules/ecr/variables.tf
+++ b/infra/modules/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+}

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -1,0 +1,3 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.cluster_name
+}

--- a/infra/modules/ecs/outputs.tf
+++ b/infra/modules/ecs/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.this.name
+}
+
+output "cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_cluster.this.arn
+}

--- a/infra/modules/ecs/variables.tf
+++ b/infra/modules/ecs/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  description = "Name of the ECS cluster"
+  type        = string
+}

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -1,0 +1,16 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+}
+
+resource "aws_db_instance" "this" {
+  identifier             = var.identifier
+  engine                 = "postgres"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  username               = var.username
+  password               = var.password
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = var.vpc_security_group_ids
+  skip_final_snapshot    = true
+}

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -1,0 +1,9 @@
+output "endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "arn" {
+  description = "ARN of the RDS instance"
+  value       = aws_db_instance.this.arn
+}

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -1,0 +1,25 @@
+variable "identifier" {
+  description = "Identifier for the RDS instance"
+  type        = string
+}
+
+variable "username" {
+  description = "Master username"
+  type        = string
+}
+
+variable "password" {
+  description = "Master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "subnet_ids" {
+  description = "Subnets for the RDS subnet group"
+  type        = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "Security groups for the RDS instance"
+  type        = list(string)
+}

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  acl    = "private"
+}

--- a/infra/modules/s3/outputs.tf
+++ b/infra/modules/s3/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/infra/modules/s3/variables.tf
+++ b/infra/modules/s3/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,49 @@
+output "ecr_repository_url" {
+  description = "URL of the ECR repository"
+  value       = module.ecr.repository_url
+}
+
+output "ecr_repository_arn" {
+  description = "ARN of the ECR repository"
+  value       = module.ecr.repository_arn
+}
+
+output "rds_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = module.rds.endpoint
+}
+
+output "rds_arn" {
+  description = "ARN of the RDS instance"
+  value       = module.rds.arn
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = module.ecs.cluster_name
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = module.ecs.cluster_arn
+}
+
+output "s3_bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = module.s3.bucket_domain_name
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = module.s3.bucket_arn
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = module.cloudfront.domain_name
+}
+
+output "cloudfront_arn" {
+  description = "ARN of the CloudFront distribution"
+  value       = module.cloudfront.arn
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,46 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+}
+
+variable "rds_identifier" {
+  description = "Identifier for the RDS instance"
+  type        = string
+}
+
+variable "rds_username" {
+  description = "Master username for RDS"
+  type        = string
+}
+
+variable "rds_password" {
+  description = "Master password for RDS"
+  type        = string
+  sensitive   = true
+}
+
+variable "rds_subnet_ids" {
+  description = "List of subnet IDs for RDS subnet group"
+  type        = list(string)
+}
+
+variable "rds_vpc_security_group_ids" {
+  description = "List of VPC security group IDs for the RDS instance"
+  type        = list(string)
+}
+
+variable "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Terraform modules for ECR, RDS, ECS, S3 and CloudFront
- expose outputs for repository URLs, endpoints, domain names and ARNs
- ignore Terraform state and local directories

## Testing
- `terraform -chdir=infra fmt -recursive`
- `terraform -chdir=infra init -backend=false`
- `terraform -chdir=infra validate`

------
https://chatgpt.com/codex/tasks/task_e_68a1a98ed60c8328a30d5b75688feffe